### PR TITLE
WIP Refactor to use references of propositions and actions

### DIFF
--- a/benches/plangraph.rs
+++ b/benches/plangraph.rs
@@ -26,11 +26,11 @@ fn plangraph_benchmark(c: &mut Criterion) {
         hashset!{&not_p2},
     );
 
-    c.bench_function("plangraph 100", move |b| b.iter(||{
+    c.bench_function("plangraph 100", |b| b.iter(||{
         let mut pg = PlanGraph::new(
-            hashset!{p1.clone(), p2.clone(), p3.clone()},
-            hashset!{not_p1.clone(), not_p2.clone(), p3.clone()},
-            hashset!{a1.clone(), a2.clone()}
+            hashset!{&p1, &p2, &p3},
+            hashset!{&not_p1, &not_p2, &p3},
+            hashset!{&a1, &a2}
         );
         for _ in 0..100 {
             pg.extend();

--- a/benches/solver.rs
+++ b/benches/solver.rs
@@ -30,11 +30,12 @@ fn solver_benchmark(c: &mut Criterion) {
     );
 
     c.bench_function("solve 100", |b| b.iter(||{
-        let mut pg = GraphPlan::new(
+        let domain = GraphPlan::create_domain(
             hashset!{&p1, &p5},
             hashset!{&p3, &p6},
             hashset!{&a1, &a2, &a3}
         );
+        let mut pg = GraphPlan::from_domain(&domain);
         pg.search::<SimpleSolver>();
     }));
 }

--- a/benches/solver.rs
+++ b/benches/solver.rs
@@ -1,14 +1,41 @@
 #[macro_use] extern crate criterion;
 use criterion::Criterion;
 
-use graphplan::GraphPlan;
+#[macro_use] extern crate graphplan;
+use graphplan::{GraphPlan, Proposition, Action};
 use graphplan::solver::SimpleSolver;
 
 fn solver_benchmark(c: &mut Criterion) {
-    c.bench_function("solve 100", move |b| b.iter(||{
-        let path = String::from("resources/rocket_domain.toml");
-        let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
-        pg.search();
+    let p1 = Proposition::from("rocket1_location1");
+    let p2 = Proposition::from("rocket1_location2");
+    let p3 = Proposition::from("rocket1_location3");
+    let _p4 = Proposition::from("rocket2_location1");
+    let p5 = Proposition::from("rocket2_location2");
+    let p6 = Proposition::from("rocket2_location3");
+
+    let a1 = Action::new(
+       "move_rocket1_location2",
+       hashset!{&p1},
+       hashset!{&p2},
+    );
+    let a2 = Action::new(
+       "move_rocket1_location3",
+       hashset!{&p2},
+       hashset!{&p3},
+    );
+    let a3 = Action::new(
+       "move_rocket2_location3",
+       hashset!{&p5},
+       hashset!{&p6},
+    );
+
+    c.bench_function("solve 100", |b| b.iter(||{
+        let mut pg = GraphPlan::new(
+            hashset!{&p1, &p5},
+            hashset!{&p3, &p6},
+            hashset!{&a1, &a2, &a3}
+        );
+        pg.search::<SimpleSolver>();
     }));
 }
 

--- a/resources/rocket_domain.toml
+++ b/resources/rocket_domain.toml
@@ -5,7 +5,7 @@ initial = [
 
 goals = [
   "rocket1_location3",
-  "rocket1_location3",
+  "rocket2_location3",
 ]
 
 actions = [

--- a/src/action.rs
+++ b/src/action.rs
@@ -111,11 +111,13 @@ mod test_action {
 
     #[test]
     fn maintenance_action_works() {
-        let m: Action<TestActionId, &str> = Action::new_maintenance(Proposition::from("test"));
-        let m2 = Action::new_maintenance(Proposition::from("test"));
-        assert_eq!(m, m2.clone());
+        let p1 = Proposition::from("test");
+        let p2 = Proposition::from("test2");
+        let m1: Action<TestActionId, &str> = Action::new_maintenance(&p1);
+        let m2 = Action::new_maintenance(&p1);
+        assert_eq!(m1, m2);
 
-        let m3 = Action::new_maintenance(Proposition::from("test2"));
+        let m3 = Action::new_maintenance(&p2);
         assert_ne!(m2, m3);
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -55,9 +55,9 @@ impl<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
         }
     }
 
-    pub fn action_mutexes<'a>(actions: &HashSet<&'a Action<ActionId, PropositionId>>,
-                              mutex_props: Option<&MutexPairs<Proposition<PropositionId>>>)
-                              -> MutexPairs<&'a Action<ActionId, PropositionId>> {
+    pub fn action_mutexes(actions: &HashSet<Action<ActionId, PropositionId>>,
+                          mutex_props: Option<&MutexPairs<Proposition<PropositionId>>>)
+                          -> MutexPairs<Action<ActionId, PropositionId>> {
         let mut mutexes = MutexPairs::new();
         let action_pairs = pairs(&actions);
 
@@ -137,8 +137,8 @@ impl<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
     /// - All ways of achieving the propositions at are pairwise mutex
     pub fn proposition_mutexes(
         props: &HashSet<Proposition<PropositionId>>,
-        actions: &HashSet<&Action<ActionId, PropositionId>>,
-        mutex_actions: Option<&MutexPairs<&Action<ActionId, PropositionId>>>,
+        actions: &HashSet<Action<ActionId, PropositionId>>,
+        mutex_actions: Option<&MutexPairs<Action<ActionId, PropositionId>>>,
     ) -> MutexPairs<Proposition<PropositionId>> {
         let mut mutexes = MutexPairs::new();
 
@@ -157,12 +157,12 @@ impl<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
         // - If there is no difference then the props are mutex
         if let Some(mx_actions) = mutex_actions {
             for PairSet(p1, p2) in pairs(&props) {
-                let viable_acts: HashSet<&Action<_, _>> = actions.iter()
+                let viable_acts: HashSet<Action<_, _>> = actions.iter()
                     .filter(|a| a.effects.contains(&p1) || a.effects.contains(&p2))
                     .map(|a| a.to_owned())
                     .collect();
 
-                let viable_act_pairs: HashSet<PairSet<&Action<_, _>>> = pairs(&viable_acts)
+                let viable_act_pairs: HashSet<PairSet<Action<_, _>>> = pairs(&viable_acts)
                     .into_iter()
                     .collect();
 
@@ -237,7 +237,7 @@ mod mutex_test {
             hashset!{},
             hashset!{&p2},
         );
-        let action_mutexes = hashset!{PairSet(&a1, &a2)};
+        let action_mutexes = hashset!{PairSet(a1.clone(), a2.clone())};
         let expected = hashset!{PairSet(p1.clone(), p2.clone())};
         let props = hashset!{p1, p2};
         assert_eq!(
@@ -261,12 +261,12 @@ mod mutex_test {
             hashset!{},
             hashset!{&prop}
         );
-        let actions = hashset!{&a1, &a2};
+        let actions = hashset!{a1.clone(), a2.clone()};
         let props = MutexPairs::new();
         let actual = Layer::action_mutexes(&actions, Some(&props));
 
         let mut expected = MutexPairs::new();
-        expected.insert(PairSet(&a1, &a2));
+        expected.insert(PairSet(a1, a2));
 
         assert_eq!(expected, actual);
     }
@@ -286,12 +286,12 @@ mod mutex_test {
             hashset!{&prop},
             hashset!{&not_prop}
         );
-        let actions = hashset!{&a1, &a2};
+        let actions = hashset!{a1.clone(), a2.clone()};
         let props = MutexPairs::new();
         let actual = Layer::action_mutexes(&actions, Some(&props));
 
         let mut expected = MutexPairs::new();
-        expected.insert(PairSet(&a1, &a2));
+        expected.insert(PairSet(a1, a2));
 
         assert_eq!(expected, actual);
     }
@@ -311,13 +311,13 @@ mod mutex_test {
             hashset!{&prop},
             hashset!{&not_prop}
         );
-        let actions = hashset!{&a1, &a2};
+        let actions = hashset!{a1.clone(), a2.clone()};
         let mut mutex_props = MutexPairs::new();
         mutex_props.insert(PairSet(prop.clone(), prop.negate()));
         let actual = Layer::action_mutexes(&actions, Some(&mutex_props));
 
         let mut expected = MutexPairs::new();
-        expected.insert(PairSet(&a1, &a2));
+        expected.insert(PairSet(a1, a2));
 
         assert_eq!(expected, actual);
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -167,20 +167,19 @@ impl<'a,
         // - If there is no difference then the props are mutex
         if let Some(mx_actions) = mutex_actions {
             for PairSet(p1, p2) in pairs(&props) {
-                let viable_acts: HashSet<&Action<_, _>> = actions.iter()
+                let viable_acts = actions.iter()
                     .filter(|a| a.effects.contains(&p1) || a.effects.contains(&p2))
-                    .map(|a| a.to_owned())
+                    .map(|a| *a)
                     .collect();
 
-                let viable_act_pairs: HashSet<PairSet<&Action<_, _>>> = pairs(&viable_acts)
-                    .into_iter()
-                    .collect();
+                let viable_act_pairs = pairs(&viable_acts);
 
-                let diff: HashSet<_> = viable_act_pairs
+                let no_diff = viable_act_pairs
                     .difference(&mx_actions)
-                    .collect();
+                    .next()
+                    .is_none();
 
-                if diff.is_empty() && !mx_actions.is_empty() {
+                if no_diff && mx_actions.iter().next().is_some() {
                     mutexes.insert(PairSet(p1, p2));
                 }
             }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -25,8 +25,8 @@ impl<'a,
     Layer<'a, ActionId, PropositionId> {
     /// Create a new layer from another. ActionLayer returns a
     /// PropositionLayer and PropositionLayer returns an ActionLayer
-    pub fn from_layer(all_actions: HashSet<&'a Action<ActionId, PropositionId>>,
-                      layer: &'a Layer<ActionId, PropositionId>) -> Layer<'a, ActionId, PropositionId> {
+    pub fn from_layer<'b>(all_actions: &'b HashSet<&'a Action<ActionId, PropositionId>>,
+                          layer: &'b Layer<'a, ActionId, PropositionId>) -> Layer<'a, ActionId, PropositionId> {
         match layer {
             Layer::ActionLayer(actions) => {
                 let mut layer_data = PropositionLayerData::new();
@@ -198,7 +198,8 @@ mod from_layer_test {
         let prop = Proposition::from("test");
         let action = Action::new_maintenance(&prop);
         let layer = Layer::<&str, &str>::PropositionLayer(hashset!{&prop});
-        let actual = Layer::from_layer(hashset!{}, &layer);
+        let actions = hashset!{&action};
+        let actual = Layer::from_layer(&actions, &layer);
         let expected = Layer::ActionLayer(hashset!{&action});
         assert_eq!(expected, actual);
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,23 +7,25 @@ use crate::pairset::{PairSet, pairs, pairs_from_sets};
 
 
 pub type ActionLayerData<ActionId, PropositionId> = HashSet<Action<ActionId, PropositionId>>;
-pub type PropositionLayerData<PropositionId> = HashSet<Proposition<PropositionId>>;
+pub type PropositionLayerData<'a, PropositionId> = HashSet<&'a Proposition<PropositionId>>;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
-pub enum Layer<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
+pub enum Layer<'a,
+               ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
                PropositionId: Eq + Hash + Ord + PartialOrd + Clone + Debug + Display> {
     ActionLayer(ActionLayerData<ActionId, PropositionId>),
-    PropositionLayer(PropositionLayerData<PropositionId>),
+    PropositionLayer(PropositionLayerData<'a, PropositionId>),
 }
 
 pub type MutexPairs<T> = HashSet<PairSet<T>>;
 
-impl<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
+impl<'a,
+     ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
      PropositionId: Eq + Hash + Ord + PartialOrd + Clone + Debug + Display>
-    Layer<ActionId, PropositionId> {
+    Layer<'a, ActionId, PropositionId> {
     /// Create a new layer from another. ActionLayer returns a
     /// PropositionLayer and PropositionLayer returns an ActionLayer
-    pub fn from_layer(all_actions: HashSet<&Action<ActionId, PropositionId>>, layer: &Layer<ActionId, PropositionId>) -> Layer<ActionId, PropositionId> {
+    pub fn from_layer(all_actions: HashSet<&Action<ActionId, PropositionId>>, layer: &Layer<ActionId, PropositionId>) -> Layer<'a, ActionId, PropositionId> {
         match layer {
             Layer::ActionLayer(actions) => {
                 let mut layer_data = PropositionLayerData::new();
@@ -56,8 +58,8 @@ impl<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
     }
 
     pub fn action_mutexes(actions: &HashSet<Action<ActionId, PropositionId>>,
-                          mutex_props: Option<&MutexPairs<Proposition<PropositionId>>>)
-                          -> MutexPairs<Action<ActionId, PropositionId>> {
+                          mutex_props: Option<&MutexPairs<&Proposition<PropositionId>>>)
+                          -> MutexPairs<&'a Action<ActionId, PropositionId>> {
         let mut mutexes = MutexPairs::new();
         let action_pairs = pairs(&actions);
 
@@ -136,10 +138,10 @@ impl<ActionId: Eq + Hash + Ord + PartialOrd + Clone + Debug,
     /// - They are negations of one another
     /// - All ways of achieving the propositions at are pairwise mutex
     pub fn proposition_mutexes(
-        props: &HashSet<Proposition<PropositionId>>,
+        props: &HashSet<&Proposition<PropositionId>>,
         actions: &HashSet<Action<ActionId, PropositionId>>,
-        mutex_actions: Option<&MutexPairs<Action<ActionId, PropositionId>>>,
-    ) -> MutexPairs<Proposition<PropositionId>> {
+        mutex_actions: Option<MutexPairs<&Action<ActionId, PropositionId>>>,
+    ) -> MutexPairs<&'a Proposition<PropositionId>> {
         let mut mutexes = MutexPairs::new();
 
         // Find mutexes due to negation

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use std::collections::{HashSet};
 use crate::proposition::Proposition;
 use crate::action::Action;
-use crate::pairset::{PairSet, pairs, pairs_from_sets};
+use crate::pairset::{PairSet, pairs, pairs_from_borrowed_sets};
 
 
 pub type ActionLayerData<'a, ActionId, PropositionId> = HashSet<&'a Action<'a, ActionId, PropositionId>>;
@@ -124,7 +124,7 @@ impl<'a,
             //   to proposition mutees
             // - Check for intersection with mutex props
             if let Some(mx_props) = mutex_props {
-                let req_pairs = pairs_from_sets(a1.clone().reqs, a2.clone().reqs);
+                let req_pairs = pairs_from_borrowed_sets(&a1.reqs, &a2.reqs);
                 let competing_needs = req_pairs
                     .intersection(mx_props)
                     .next()

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -41,7 +41,6 @@ impl<'a,
             Layer::PropositionLayer(props) => {
                 let mut layer_data = ActionLayerData::new();
 
-                // TODO: come back to this when Action.reqs is a hashset of references
                 for a in all_actions {
                     // Include action if it satisfies one or more props
                     if a.reqs.is_subset(props) {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -6,7 +6,7 @@ use crate::action::Action;
 use crate::pairset::{PairSet, pairs, pairs_from_sets};
 
 
-pub type ActionLayerData<'a, ActionId, PropositionId> = HashSet<&'a Action<ActionId, PropositionId>>;
+pub type ActionLayerData<'a, ActionId, PropositionId> = HashSet<&'a Action<'a, ActionId, PropositionId>>;
 pub type PropositionLayerData<'a, PropositionId> = HashSet<&'a Proposition<PropositionId>>;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -25,7 +25,7 @@ impl<'a,
     Layer<'a, ActionId, PropositionId> {
     /// Create a new layer from another. ActionLayer returns a
     /// PropositionLayer and PropositionLayer returns an ActionLayer
-    pub fn from_layer(all_actions: HashSet<&Action<ActionId, PropositionId>>,
+    pub fn from_layer(all_actions: HashSet<&'a Action<ActionId, PropositionId>>,
                       layer: &'a Layer<ActionId, PropositionId>) -> Layer<'a, ActionId, PropositionId> {
         match layer {
             Layer::ActionLayer(actions) => {
@@ -42,12 +42,12 @@ impl<'a,
                 let mut layer_data = ActionLayerData::new();
 
                 // TODO: come back to this when Action.reqs is a hashset of references
-                // for a in all_actions {
-                //     // Include action if it satisfies one or more props
-                //     if a.reqs.is_subset(props) {
-                //         layer_data.insert(a.to_owned());
-                //     }
-                // }
+                for a in all_actions {
+                    // Include action if it satisfies one or more props
+                    if a.reqs.is_subset(props) {
+                        layer_data.insert(a);
+                    }
+                }
 
                 // TODO: Move creation of maintenance actions out of
                 // here otherwise it will conflict with the lifetime
@@ -64,7 +64,7 @@ impl<'a,
 
     pub fn action_mutexes(actions: &HashSet<&'a Action<ActionId, PropositionId>>,
                           mutex_props: Option<&MutexPairs<&Proposition<PropositionId>>>)
-                          -> MutexPairs<&'a Action<ActionId, PropositionId>> {
+                          -> MutexPairs<&'a Action<'a, ActionId, PropositionId>> {
         let mut mutexes = MutexPairs::new();
 
         for PairSet(a1, a2) in pairs(&actions) {
@@ -78,23 +78,25 @@ impl<'a,
                 .iter()
                 .map(|e| e.negate())
                 .collect();
-            let inconsistent_fx: HashSet<Proposition<PropositionId>> = a2.effects
-                .intersection(&negated_fx)
+            let inconsistent_fx = a2.effects
+                .intersection(&negated_fx.iter().collect())
                 .map(|i| i.to_owned())
-                .collect();
-            if !inconsistent_fx.is_empty() {
+                .next()
+                .is_some();
+            if inconsistent_fx {
                 mutexes.insert(PairSet(a1, a2));
                 continue
             }
 
             // Interference: One action deletes the precondition of
             // another action (they can't be done in parallel then)
-            let left_interference: HashSet<Proposition<PropositionId>> = a2.reqs
-                .intersection(&negated_fx)
+            let left_interference = a2.reqs
+                .intersection(&negated_fx.iter().collect())
                 .map(|i| i.to_owned())
-                .collect();
+                .next()
+                .is_some();
 
-            if !left_interference.is_empty() {
+            if left_interference {
                 mutexes.insert(PairSet(a1, a2));
                 continue
             }
@@ -102,16 +104,17 @@ impl<'a,
             // Since actions are not symetrical (they may have different
             // reqs) we need to check if the right hand side action
             // interferes with left hand side too
-            let right_negated_fx: HashSet<Proposition<PropositionId>> = a2.clone().effects
+            let right_negated_fx: HashSet<Proposition<PropositionId>> = a2.effects
                 .iter()
                 .map(|e| e.negate())
                 .collect();
-            let right_interference: HashSet<Proposition<PropositionId>> = a1.clone().reqs
-                .intersection(&right_negated_fx)
+            let right_interference = a1.reqs
+                .intersection(&right_negated_fx.iter().collect())
                 .map(|i| i.to_owned())
-                .collect();
+                .next()
+                .is_some();
 
-            if !right_interference.is_empty() {
+            if right_interference {
                 mutexes.insert(PairSet(a1, a2));
                 continue
             }
@@ -122,15 +125,15 @@ impl<'a,
             //   to proposition mutees
             // - Check for intersection with mutex props
             if let Some(mx_props) = mutex_props {
-                // TODO: come back to this when Action.reqs is a set of references
-                // let req_pairs = pairs_from_sets(a1.clone().reqs, a2.clone().reqs);
-                // let competing_needs = req_pairs
-                //     .intersection(mx_props)
-                //     .collect();
+                let req_pairs = pairs_from_sets(a1.clone().reqs, a2.clone().reqs);
+                let competing_needs = req_pairs
+                    .intersection(mx_props)
+                    .next()
+                    .is_some();
 
-                // if !competing_needs.is_empty() {
-                //     mutexes.insert(PairSet(a1, a2));
-                // }
+                if competing_needs {
+                    mutexes.insert(PairSet(a1, a2));
+                }
             }
         }
         mutexes
@@ -152,8 +155,8 @@ impl<'a,
         for p in props.iter() {
             let not_p = p.negate();
             if props.contains(&not_p) {
-                // FIX this won't work because this is a
-                // reference to a owned prop in this scope
+                // TODO: this won't work because this is a reference
+                // to a owned prop in this scope
                 // mutexes.insert(PairSet(*p, &not_p));
             }
         }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -144,6 +144,7 @@ impl<'a,
                 let not_p = p.negate();
                 if a2.reqs.contains(&not_p) {
                     mutexes.insert(PairSet(a1, a2));
+                    break
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,41 +118,43 @@ impl<'a,
 
 impl<'a> GraphPlan<'a, String, String> {
     #[cfg(any(feature = "toml", feature = "wasm"))]
-    pub fn from_toml_string(string: String) -> (HashSet<Proposition<String>>, HashSet<Proposition<String>>, HashSet<Action<'a, String, String>>) {
-        let config: Config = toml::from_str(&string).expect("Fail");
-        let initial_props: HashSet<Proposition<String>> = config.initial
-            .iter()
-            .map(|i| Proposition::new(i.replace("not_", ""),
-                                      i.starts_with("not_")))
-            .collect();
-        let goals: HashSet<Proposition<String>> = config.goals
-            .iter()
-            .map(|i| Proposition::new(i.replace("not_", ""),
-                                      i.starts_with("not_")))
-            .collect();
-        let actions: HashSet<Action<String, String>> = config.actions
-            .iter()
-            .map(|i| {
-                let reqs: HashSet<Proposition<String>> = i.reqs.iter()
-                    .map(|r| Proposition::new(r.replace("not_", ""),
-                                              r.starts_with("not_")))
-                    .collect();
-                let effects: HashSet<Proposition<String>> = i.effects.iter()
-                    .map(|e| Proposition::new(e.replace("not_", ""),
-                                              e.starts_with("not_")))
-                    .collect();
-                Action::new(
-                    i.name.to_string(),
-                    reqs,
-                    effects
-                )
-            })
-            .collect();
-        (initial_props, goals, actions)
+    pub fn from_toml_string(string: String) -> GraphPlan<'a, String, String> {
+        unimplemented!();
+        // let config: Config = toml::from_str(&string).expect("Fail");
+        // let initial_props: HashSet<Proposition<String>> = config.initial
+        //     .iter()
+        //     .map(|i| Proposition::new(i.replace("not_", ""),
+        //                               i.starts_with("not_")))
+        //     .collect();
+        // let goals: HashSet<Proposition<String>> = config.goals
+        //     .iter()
+        //     .map(|i| Proposition::new(i.replace("not_", ""),
+        //                               i.starts_with("not_")))
+        //     .collect();
+        // let actions: HashSet<Action<String, String>> = config.actions
+        //     .iter()
+        //     .map(|i| {
+        //         let reqs: HashSet<Proposition<String>> = i.reqs.iter()
+        //             .map(|r| Proposition::new(r.replace("not_", ""),
+        //                                       r.starts_with("not_")))
+        //             .collect();
+        //         let effects: HashSet<Proposition<String>> = i.effects.iter()
+        //             .map(|e| Proposition::new(e.replace("not_", ""),
+        //                                       e.starts_with("not_")))
+        //             .collect();
+        //         Action::new(
+        //             i.name.to_string(),
+        //             reqs,
+        //             effects
+        //         )
+        //     })
+        //     .collect();
+        // (initial_props, goals, actions)
+        // GraphPlan::new(initial_props, goals, actions)
     }
 
     #[cfg(any(feature = "toml", feature = "wasm"))]
-    pub fn from_toml(filepath: String) -> (HashSet<Proposition<String>>, HashSet<Proposition<String>>, HashSet<Action<'a, String, String>>) {
+    pub fn from_toml(filepath: String) -> GraphPlan<'a, String, String> {
         let string = fs::read_to_string(filepath).expect("Failed to read file");
         GraphPlan::from_toml_string(string)
     }
@@ -195,8 +197,9 @@ mod integration_test {
     #[cfg(any(feature = "toml", feature = "wasm"))]
     #[test]
     fn load_from_toml_config() {
-        let path = String::from("resources/rocket_domain.toml");
-        let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
-        assert!(pg.search() != None, "Solution should not be None");
+        unimplemented!()
+        // let path = String::from("resources/rocket_domain.toml");
+        // let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
+        // assert!(pg.search() != None, "Solution should not be None");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-use std::collections::{HashSet};
-use std::hash::Hash;
-use std::fmt::{Debug, Display};
+// use std::collections::{HashSet};
+// use std::hash::Hash;
+// use std::fmt::{Debug, Display};
 
 #[cfg(any(feature = "toml", feature = "wasm"))]
 #[macro_use] extern crate serde_derive;
@@ -28,136 +28,136 @@ pub use crate::action::Action;
 pub use crate::plangraph::{PlanGraph, Solution};
 pub use crate::solver::{GraphPlanSolver, SimpleSolver};
 
-#[cfg(any(feature = "toml", feature = "wasm"))]
-#[derive(Deserialize)]
-struct Config {
-    initial: Vec<String>,
-    goals: Vec<String>,
-    actions: Vec<ConfigAction>
-}
+// #[cfg(any(feature = "toml", feature = "wasm"))]
+// #[derive(Deserialize)]
+// struct Config {
+//     initial: Vec<String>,
+//     goals: Vec<String>,
+//     actions: Vec<ConfigAction>
+// }
 
-#[cfg(any(feature = "toml", feature = "wasm"))]
-#[derive(Deserialize)]
-struct ConfigAction {
-    name: String,
-    reqs: Vec<String>,
-    effects: Vec<String>,
-}
+// #[cfg(any(feature = "toml", feature = "wasm"))]
+// #[derive(Deserialize)]
+// struct ConfigAction {
+//     name: String,
+//     reqs: Vec<String>,
+//     effects: Vec<String>,
+// }
 
-pub struct GraphPlan<ActionId: Debug + Hash + Ord + Clone,
-                     PropositionId: Debug + Display + Hash + Ord + Clone,
-                     T: GraphPlanSolver<ActionId, PropositionId>> {
-    pub solver: T,
-    pub plangraph: PlanGraph<ActionId, PropositionId>,
-}
+// pub struct GraphPlan<ActionId: Debug + Hash + Ord + Clone,
+//                      PropositionId: Debug + Display + Hash + Ord + Clone,
+//                      T: GraphPlanSolver<ActionId, PropositionId>> {
+//     pub solver: T,
+//     pub plangraph: PlanGraph<ActionId, PropositionId>,
+// }
 
-impl<ActionId: Debug + Hash + Ord + Clone,
-     PropositionId: Debug + Display + Hash + Ord + Clone,
-     T: GraphPlanSolver<ActionId, PropositionId>> GraphPlan<ActionId, PropositionId, T> {
-    pub fn new(initial_props: HashSet<Proposition<PropositionId>>,
-               goals: HashSet<Proposition<PropositionId>>,
-               actions: HashSet<Action<ActionId, PropositionId>>,
-               solver: T) -> GraphPlan<ActionId, PropositionId, T> {
-        let pg = PlanGraph::new(initial_props, goals, actions);
-        GraphPlan {
-            solver,
-            plangraph: pg
-        }
-    }
+// impl<ActionId: Debug + Hash + Ord + Clone,
+//      PropositionId: Debug + Display + Hash + Ord + Clone,
+//      T: GraphPlanSolver<ActionId, PropositionId>> GraphPlan<ActionId, PropositionId, T> {
+//     pub fn new(initial_props: HashSet<Proposition<PropositionId>>,
+//                goals: HashSet<Proposition<PropositionId>>,
+//                actions: HashSet<Action<ActionId, PropositionId>>,
+//                solver: T) -> GraphPlan<ActionId, PropositionId, T> {
+//         let pg = PlanGraph::new(initial_props, goals, actions);
+//         GraphPlan {
+//             solver,
+//             plangraph: pg
+//         }
+//     }
 
-    pub fn search(&mut self) -> Option<Solution<ActionId, PropositionId>>{
-        self.plangraph.search_with(&self.solver)
-    }
-}
+//     pub fn search(&mut self) -> Option<Solution<ActionId, PropositionId>>{
+//         self.plangraph.search_with(&self.solver)
+//     }
+// }
 
-impl GraphPlan<String, String, SimpleSolver> {
-    #[cfg(any(feature = "toml", feature = "wasm"))]
-    pub fn from_toml_string(string: String) -> GraphPlan<String, String, SimpleSolver> {
-        let config: Config = toml::from_str(&string).expect("Fail");
-        let initial_props: HashSet<Proposition<String>> = config.initial
-            .iter()
-            .map(|i| Proposition::new(i.to_owned().replace("not_", ""),
-                                      i.starts_with("not_")))
-            .collect();
-        let goals: HashSet<Proposition<String>> = config.goals
-            .iter()
-            .map(|i| Proposition::new(i.to_owned().replace("not_", ""),
-                                      i.starts_with("not_")))
-            .collect();
-        let actions: HashSet<Action<String, String>> = config.actions
-            .iter()
-            .map(|i| {
-                let reqs: HashSet<Proposition<String>> = i.reqs.iter()
-                    .map(|r| Proposition::new(r.clone().replace("not_", ""),
-                                              r.starts_with("not_")))
-                    .collect();
-                let effects: HashSet<Proposition<String>> = i.effects.iter()
-                    .map(|e| Proposition::new(e.clone().replace("not_", ""),
-                                              e.starts_with("not_")))
-                    .collect();
-                Action::new(
-                    i.name.to_string(),
-                    reqs.iter().collect(),
-                    effects.iter().collect()
-                )
-            })
-            .collect();
-        let solver = SimpleSolver::default();
-        GraphPlan::new(
-            initial_props,
-            goals,
-            actions,
-            solver
-        )
-    }
+// impl GraphPlan<String, String, SimpleSolver> {
+//     #[cfg(any(feature = "toml", feature = "wasm"))]
+//     pub fn from_toml_string(string: String) -> GraphPlan<String, String, SimpleSolver> {
+//         let config: Config = toml::from_str(&string).expect("Fail");
+//         let initial_props: HashSet<Proposition<String>> = config.initial
+//             .iter()
+//             .map(|i| Proposition::new(i.to_owned().replace("not_", ""),
+//                                       i.starts_with("not_")))
+//             .collect();
+//         let goals: HashSet<Proposition<String>> = config.goals
+//             .iter()
+//             .map(|i| Proposition::new(i.to_owned().replace("not_", ""),
+//                                       i.starts_with("not_")))
+//             .collect();
+//         let actions: HashSet<Action<String, String>> = config.actions
+//             .iter()
+//             .map(|i| {
+//                 let reqs: HashSet<Proposition<String>> = i.reqs.iter()
+//                     .map(|r| Proposition::new(r.clone().replace("not_", ""),
+//                                               r.starts_with("not_")))
+//                     .collect();
+//                 let effects: HashSet<Proposition<String>> = i.effects.iter()
+//                     .map(|e| Proposition::new(e.clone().replace("not_", ""),
+//                                               e.starts_with("not_")))
+//                     .collect();
+//                 Action::new(
+//                     i.name.to_string(),
+//                     reqs.iter().collect(),
+//                     effects.iter().collect()
+//                 )
+//             })
+//             .collect();
+//         let solver = SimpleSolver::default();
+//         GraphPlan::new(
+//             initial_props,
+//             goals,
+//             actions,
+//             solver
+//         )
+//     }
 
-    #[cfg(any(feature = "toml", feature = "wasm"))]
-    pub fn from_toml(filepath: String) -> GraphPlan<String, String, SimpleSolver> {
-        let string = fs::read_to_string(filepath).expect("Failed to read file");
-        GraphPlan::from_toml_string(string)
-    }
-}
+//     #[cfg(any(feature = "toml", feature = "wasm"))]
+//     pub fn from_toml(filepath: String) -> GraphPlan<String, String, SimpleSolver> {
+//         let string = fs::read_to_string(filepath).expect("Failed to read file");
+//         GraphPlan::from_toml_string(string)
+//     }
+// }
 
-#[cfg(test)]
-mod integration_test {
-    use crate::GraphPlan;
-    use crate::proposition::Proposition;
-    use crate::action::Action;
-    use crate::solver::SimpleSolver;
+// #[cfg(test)]
+// mod integration_test {
+//     use crate::GraphPlan;
+//     use crate::proposition::Proposition;
+//     use crate::action::Action;
+//     use crate::solver::SimpleSolver;
 
-    #[test]
-    fn integration() {
-        let p1 = Proposition::from("tired");
-        let not_p1 = p1.negate();
-        let p2 = Proposition::from("dog needs to pee");
-        let not_p2 = p2.negate();
+//     #[test]
+//     fn integration() {
+//         let p1 = Proposition::from("tired");
+//         let not_p1 = p1.negate();
+//         let p2 = Proposition::from("dog needs to pee");
+//         let not_p2 = p2.negate();
 
-        let a1 = Action::new(
-            String::from("coffee"),
-            hashset!{&p1},
-            hashset!{&not_p1}
-        );
+//         let a1 = Action::new(
+//             String::from("coffee"),
+//             hashset!{&p1},
+//             hashset!{&not_p1}
+//         );
 
-        let a2 = Action::new(
-            String::from("walk dog"),
-            hashset!{&p2, &not_p1},
-            hashset!{&not_p2},
-        );
+//         let a2 = Action::new(
+//             String::from("walk dog"),
+//             hashset!{&p2, &not_p1},
+//             hashset!{&not_p2},
+//         );
 
-        let mut pg = GraphPlan::new(
-            hashset!{p1, p2},
-            hashset!{not_p1, not_p2},
-            hashset!{a1, a2},
-            SimpleSolver::default()
-        );
-        assert!(pg.search() != None, "Solution should not be None");
-    }
+//         let mut pg = GraphPlan::new(
+//             hashset!{p1, p2},
+//             hashset!{not_p1, not_p2},
+//             hashset!{a1, a2},
+//             SimpleSolver::default()
+//         );
+//         assert!(pg.search() != None, "Solution should not be None");
+//     }
 
-    #[cfg(any(feature = "toml", feature = "wasm"))]
-    #[test]
-    fn load_from_toml_config() {
-        let path = String::from("resources/rocket_domain.toml");
-        let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
-        assert!(pg.search() != None, "Solution should not be None");
-    }
-}
+//     #[cfg(any(feature = "toml", feature = "wasm"))]
+//     #[test]
+//     fn load_from_toml_config() {
+//         let path = String::from("resources/rocket_domain.toml");
+//         let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
+//         assert!(pg.search() != None, "Solution should not be None");
+//     }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
-// use std::collections::{HashSet};
-// use std::hash::Hash;
-// use std::fmt::{Debug, Display};
+use std::collections::{HashSet};
+use std::hash::Hash;
+use std::fmt::{Debug, Display};
+use log::{debug};
 
 #[cfg(any(feature = "toml", feature = "wasm"))]
 #[macro_use] extern crate serde_derive;
@@ -23,191 +24,179 @@ pub mod solver;
 mod layer;
 mod pairset;
 
-// pub use crate::proposition::Proposition;
-// pub use crate::action::Action;
-// pub use crate::plangraph::{PlanGraph, Solution};
-// pub use crate::solver::{GraphPlanSolver, SimpleSolver};
+pub use crate::proposition::Proposition;
+pub use crate::action::{Action, ActionType};
+pub use crate::plangraph::{PlanGraph, Solution};
+pub use crate::solver::{GraphPlanSolver, SimpleSolver};
 
-// #[cfg(any(feature = "toml", feature = "wasm"))]
-// #[derive(Deserialize)]
-// struct Config {
-//     initial: Vec<String>,
-//     goals: Vec<String>,
-//     actions: Vec<ConfigAction>
-// }
+#[cfg(any(feature = "toml", feature = "wasm"))]
+#[derive(Deserialize)]
+struct Config {
+    initial: Vec<String>,
+    goals: Vec<String>,
+    actions: Vec<ConfigAction>
+}
 
-// #[cfg(any(feature = "toml", feature = "wasm"))]
-// #[derive(Deserialize)]
-// struct ConfigAction {
-//     name: String,
-//     reqs: Vec<String>,
-//     effects: Vec<String>,
-// }
+#[cfg(any(feature = "toml", feature = "wasm"))]
+#[derive(Deserialize)]
+struct ConfigAction {
+    name: String,
+    reqs: Vec<String>,
+    effects: Vec<String>,
+}
 
-// pub struct GraphPlan<ActionId: Debug + Hash + Ord + Clone,
-//                      PropositionId: Debug + Display + Hash + Ord + Clone,
-//                      T: GraphPlanSolver<ActionId, PropositionId>> {
-//     pub solver: T,
-//     pub plangraph: PlanGraph<ActionId, PropositionId>,
-// }
+pub struct GraphPlan<'a,
+                     ActionId: Debug + Hash + Ord + Clone,
+                     PropositionId: Debug + Display + Hash + Ord + Clone> {
+    plangraph: PlanGraph<'a, ActionId, PropositionId>,
+}
 
-// impl<ActionId: Debug + Hash + Ord + Clone,
-//      PropositionId: Debug + Display + Hash + Ord + Clone,
-//      T: GraphPlanSolver<ActionId, PropositionId>> GraphPlan<ActionId, PropositionId, T> {
-//     pub fn new(initial_props: HashSet<Proposition<PropositionId>>,
-//                goals: HashSet<Proposition<PropositionId>>,
-//                actions: HashSet<Action<ActionId, PropositionId>>,
-//                solver: T) -> GraphPlan<ActionId, PropositionId, T> {
-//         let pg = PlanGraph::new(initial_props, goals, actions);
-//         GraphPlan {
-//             solver,
-//             plangraph: pg
-//         }
-//     }
+impl<'a,
+     ActionId: Debug + Hash + Ord + Clone,
+     PropositionId: Debug + Display + Hash + Ord + Clone>
+    GraphPlan<'a, ActionId, PropositionId> {
+    pub fn new(initial_props: HashSet<&'a Proposition<PropositionId>>,
+               goals: HashSet<&'a Proposition<PropositionId>>,
+               actions: HashSet<&'a Action<'a, ActionId, PropositionId>>)
+               -> GraphPlan<'a, ActionId, PropositionId> {
+        // TODO: add in negated props for initial props and each
+        // actions req/effects
+        // TODO: add in maintenance actions for all props
+        let plangraph = PlanGraph::new(
+            initial_props,
+            goals,
+            actions,
+        );
+        GraphPlan { plangraph }
+    }
 
-//     pub fn search(&mut self) -> Option<Solution<ActionId, PropositionId>>{
-//         self.plangraph.search_with(&self.solver)
-//     }
+    pub fn search<Solver>(&mut self) -> Option<Solution<'a, ActionId, PropositionId>>
+        where Solver: GraphPlanSolver<'a, ActionId, PropositionId> {
 
-    // /// Searches the planning graph for a solution using the solver if
-    // /// there is no solution, extends the graph to depth i+1 and tries
-    // /// to solve again
-    // pub fn search_with<T>(&mut self, solver: &'a T) -> Option<Solution<'a, ActionId, PropositionId>>
-    // where T: GraphPlanSolver<'a, ActionId, PropositionId> {
-    //     let mut tries = 0;
-    //     let mut solution = None;
-    //     let max_tries = self.actions.len() + 1;
+        let mut tries = 0;
+        let mut solution = None;
+        let max_tries = self.plangraph.actions.len() + 1;
 
-    //     while tries < max_tries {
-    //         // This doesn't provide early termination for _all_
-    //         // cases that won't yield a solution.
-    //         if self.has_leveled_off() {
-    //             break;
-    //         }
+        while tries < max_tries {
+            self.plangraph.extend();
+            // This doesn't provide early termination for _all_
+            // cases that won't yield a solution.
+            if self.plangraph.has_leveled_off() {
+                break;
+            }
 
-    //         if !self.has_possible_solution() {
-    //             debug!("No solution exists at depth {}", self.depth());
-    //             self.extend();
-    //             tries += 1;
-    //             continue
-    //         }
+            if !self.plangraph.has_possible_solution() {
+                debug!("No solution exists at depth {}", self.plangraph.depth());
+                tries += 1;
+                continue
+            }
 
-    //         if let Some(result) = solver.search(self) {
-    //             solution = Some(result);
-    //             break;
-    //         } else {
-    //             debug!("No solution found at depth {}", self.depth());
-    //             self.extend();
-    //             tries += 1
-    //         }
+            if let Some(result) = Solver::search(&self.plangraph) {
+                solution = Some(result);
+                break;
+            } else {
+                debug!("No solution found at depth {}", self.plangraph.depth());
+                tries += 1
+            }
+        };
 
-    //     };
-    //     solution
-    // }
+        solution
+    }
 
-    // /// Takes a solution and filters out maintenance actions
-    // pub fn format_plan(solution: Solution<ActionId, PropositionId>) -> Solution<ActionId, PropositionId> {
-    //     solution.iter()
-    //         .map(|s| s.iter()
-    //              .filter(|i| match i.id {
-    //                  ActionType::Action(_) => true,
-    //                  ActionType::Maintenance(_) => false})
-    //              .cloned()
-    //              .collect())
-    //         .collect()
-    // }
+    /// Takes a solution and filters out maintenance actions
+    pub fn format_plan(solution: Solution<ActionId, PropositionId>) -> Solution<ActionId, PropositionId> {
+        solution.iter()
+            .map(|s| s.iter()
+                 .filter(|i| match i.id {
+                     ActionType::Action(_) => true,
+                     ActionType::Maintenance(_) => false})
+                 .cloned()
+                 .collect())
+            .collect()
+    }
+}
 
+impl<'a> GraphPlan<'a, String, String> {
+    #[cfg(any(feature = "toml", feature = "wasm"))]
+    pub fn from_toml_string(string: String) -> (HashSet<Proposition<String>>, HashSet<Proposition<String>>, HashSet<Action<'a, String, String>>) {
+        let config: Config = toml::from_str(&string).expect("Fail");
+        let initial_props: HashSet<Proposition<String>> = config.initial
+            .iter()
+            .map(|i| Proposition::new(i.replace("not_", ""),
+                                      i.starts_with("not_")))
+            .collect();
+        let goals: HashSet<Proposition<String>> = config.goals
+            .iter()
+            .map(|i| Proposition::new(i.replace("not_", ""),
+                                      i.starts_with("not_")))
+            .collect();
+        let actions: HashSet<Action<String, String>> = config.actions
+            .iter()
+            .map(|i| {
+                let reqs: HashSet<Proposition<String>> = i.reqs.iter()
+                    .map(|r| Proposition::new(r.replace("not_", ""),
+                                              r.starts_with("not_")))
+                    .collect();
+                let effects: HashSet<Proposition<String>> = i.effects.iter()
+                    .map(|e| Proposition::new(e.replace("not_", ""),
+                                              e.starts_with("not_")))
+                    .collect();
+                Action::new(
+                    i.name.to_string(),
+                    reqs,
+                    effects
+                )
+            })
+            .collect();
+        (initial_props, goals, actions)
+    }
 
-// }
+    #[cfg(any(feature = "toml", feature = "wasm"))]
+    pub fn from_toml(filepath: String) -> (HashSet<Proposition<String>>, HashSet<Proposition<String>>, HashSet<Action<'a, String, String>>) {
+        let string = fs::read_to_string(filepath).expect("Failed to read file");
+        GraphPlan::from_toml_string(string)
+    }
+}
 
-// impl GraphPlan<String, String, SimpleSolver> {
-//     #[cfg(any(feature = "toml", feature = "wasm"))]
-//     pub fn from_toml_string(string: String) -> GraphPlan<String, String, SimpleSolver> {
-//         let config: Config = toml::from_str(&string).expect("Fail");
-//         let initial_props: HashSet<Proposition<String>> = config.initial
-//             .iter()
-//             .map(|i| Proposition::new(i.to_owned().replace("not_", ""),
-//                                       i.starts_with("not_")))
-//             .collect();
-//         let goals: HashSet<Proposition<String>> = config.goals
-//             .iter()
-//             .map(|i| Proposition::new(i.to_owned().replace("not_", ""),
-//                                       i.starts_with("not_")))
-//             .collect();
-//         let actions: HashSet<Action<String, String>> = config.actions
-//             .iter()
-//             .map(|i| {
-//                 let reqs: HashSet<Proposition<String>> = i.reqs.iter()
-//                     .map(|r| Proposition::new(r.clone().replace("not_", ""),
-//                                               r.starts_with("not_")))
-//                     .collect();
-//                 let effects: HashSet<Proposition<String>> = i.effects.iter()
-//                     .map(|e| Proposition::new(e.clone().replace("not_", ""),
-//                                               e.starts_with("not_")))
-//                     .collect();
-//                 Action::new(
-//                     i.name.to_string(),
-//                     reqs.iter().collect(),
-//                     effects.iter().collect()
-//                 )
-//             })
-//             .collect();
-//         let solver = SimpleSolver::default();
-//         GraphPlan::new(
-//             initial_props,
-//             goals,
-//             actions,
-//             solver
-//         )
-//     }
+#[cfg(test)]
+mod integration_test {
+    use crate::GraphPlan;
+    use crate::proposition::Proposition;
+    use crate::action::Action;
+    use crate::solver::SimpleSolver;
 
-//     #[cfg(any(feature = "toml", feature = "wasm"))]
-//     pub fn from_toml(filepath: String) -> GraphPlan<String, String, SimpleSolver> {
-//         let string = fs::read_to_string(filepath).expect("Failed to read file");
-//         GraphPlan::from_toml_string(string)
-//     }
-// }
+    #[test]
+    fn integration() {
+        let p1 = Proposition::from("tired");
+        let not_p1 = p1.negate();
+        let p2 = Proposition::from("dog needs to pee");
+        let not_p2 = p2.negate();
 
-// #[cfg(test)]
-// mod integration_test {
-//     use crate::GraphPlan;
-//     use crate::proposition::Proposition;
-//     use crate::action::Action;
-//     use crate::solver::SimpleSolver;
+        let a1 = Action::new(
+            "coffee",
+            hashset!{&p1},
+            hashset!{&not_p1}
+        );
 
-//     #[test]
-//     fn integration() {
-//         let p1 = Proposition::from("tired");
-//         let not_p1 = p1.negate();
-//         let p2 = Proposition::from("dog needs to pee");
-//         let not_p2 = p2.negate();
+        let a2 = Action::new(
+            "walk dog",
+            hashset!{&p2, &not_p1},
+            hashset!{&not_p2},
+        );
 
-//         let a1 = Action::new(
-//             String::from("coffee"),
-//             hashset!{&p1},
-//             hashset!{&not_p1}
-//         );
+        let mut pg = GraphPlan::<&str, &str>::new(
+            hashset!{&p1, &p2},
+            hashset!{&not_p1, &not_p2},
+            hashset!{&a1, &a2},
+        );
+        assert!(pg.search::<SimpleSolver>() != None, "Solution should not be None");
+    }
 
-//         let a2 = Action::new(
-//             String::from("walk dog"),
-//             hashset!{&p2, &not_p1},
-//             hashset!{&not_p2},
-//         );
-
-//         let mut pg = GraphPlan::new(
-//             hashset!{p1, p2},
-//             hashset!{not_p1, not_p2},
-//             hashset!{a1, a2},
-//             SimpleSolver::default()
-//         );
-//         assert!(pg.search() != None, "Solution should not be None");
-//     }
-
-//     #[cfg(any(feature = "toml", feature = "wasm"))]
-//     #[test]
-//     fn load_from_toml_config() {
-//         let path = String::from("resources/rocket_domain.toml");
-//         let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
-//         assert!(pg.search() != None, "Solution should not be None");
-//     }
-// }
+    #[cfg(any(feature = "toml", feature = "wasm"))]
+    #[test]
+    fn load_from_toml_config() {
+        let path = String::from("resources/rocket_domain.toml");
+        let mut pg: GraphPlan<_, _, SimpleSolver> = GraphPlan::from_toml(path);
+        assert!(pg.search() != None, "Solution should not be None");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,10 +186,19 @@ mod integration_test {
             hashset!{&not_p2},
         );
 
+        let a3 = Action::new_maintenance(&p1);
+        let a4 = Action::new_maintenance(&not_p1);
+        let a5 = Action::new_maintenance(&p2);
+        let a6 = Action::new_maintenance(&not_p2);
+
+        let initial_props = hashset!{&p1, &p2};
+        let goals = hashset!{&not_p1, &not_p2};
+        let actions = hashset!{&a1, &a2, &a3, &a4, &a5, &a6};
+
         let mut pg = GraphPlan::<&str, &str>::new(
-            hashset!{&p1, &p2},
-            hashset!{&not_p1, &not_p2},
-            hashset!{&a1, &a2},
+            initial_props,
+            goals,
+            actions
         );
         assert!(pg.search::<SimpleSolver>() != None, "Solution should not be None");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,17 @@ struct ConfigAction {
     effects: Vec<String>,
 }
 
+/// Represents a planning domain that can generate a GraphPlan via
+/// `from_domain`. Serves as a helper object to prevent lifetime
+/// issues when auto generating things like maintenance actions
+pub struct Domain<'a,
+                  ActionId: Debug + Hash + Ord + Clone,
+                  PropositionId: Debug + Display + Hash + Ord + Clone> {
+    initial_props: HashSet<&'a Proposition<PropositionId>>,
+    goals: HashSet<&'a Proposition<PropositionId>>,
+    actions: HashSet<Action<'a, ActionId, PropositionId>>
+}
+
 pub struct GraphPlan<'a,
                      ActionId: Debug + Hash + Ord + Clone,
                      PropositionId: Debug + Display + Hash + Ord + Clone> {
@@ -53,19 +64,61 @@ pub struct GraphPlan<'a,
 
 impl<'a,
      ActionId: Debug + Hash + Ord + Clone,
-     PropositionId: Debug + Display + Hash + Ord + Clone>
-    GraphPlan<'a, ActionId, PropositionId> {
+     PropositionId: Debug + Display + Hash + Ord + Clone> GraphPlan<'a, ActionId, PropositionId> {
+
+    /// Returns a new GraphPlan. Note: you probably want to use
+    /// `from_domain` instead.
     pub fn new(initial_props: HashSet<&'a Proposition<PropositionId>>,
                goals: HashSet<&'a Proposition<PropositionId>>,
                actions: HashSet<&'a Action<'a, ActionId, PropositionId>>)
                -> GraphPlan<'a, ActionId, PropositionId> {
-        // TODO: add in maintenance actions for all props
         let plangraph = PlanGraph::new(
             initial_props,
             goals,
             actions,
         );
         GraphPlan { plangraph }
+    }
+
+    pub fn from_domain(domain: &'a Domain<'a, ActionId, PropositionId>)
+               -> GraphPlan<'a, ActionId, PropositionId> {
+        let plangraph = PlanGraph::new(
+            domain.initial_props.clone(),
+            domain.goals.clone(),
+            domain.actions.iter().collect(),
+        );
+        GraphPlan { plangraph }
+    }
+
+    /// Returns a domain with all maintenance actions.automatically
+    /// created. This is needed to avoid lifetime issues with PlanGraph
+    pub fn create_domain(initial_props: HashSet<&'a Proposition<PropositionId>>,
+                         goals: HashSet<&'a Proposition<PropositionId>>,
+                         actions: HashSet<&'a Action<'a, ActionId, PropositionId>>)
+                         -> Domain<'a, ActionId, PropositionId> {
+        let mut all_actions = HashSet::new();
+
+        for p in &initial_props {
+            all_actions.insert(Action::new_maintenance(*p));
+        }
+
+        for a in actions {
+            all_actions.insert(a.to_owned());
+
+            for p in &a.reqs {
+                all_actions.insert(Action::new_maintenance(p));
+            }
+
+            for p in &a.effects {
+                all_actions.insert(Action::new_maintenance(p));
+            }
+        }
+
+        Domain {
+            initial_props,
+            goals,
+            actions: all_actions,
+        }
     }
 
     pub fn search<Solver>(&mut self) -> Option<Solution<'a, ActionId, PropositionId>>
@@ -184,20 +237,17 @@ mod integration_test {
             hashset!{&not_p2},
         );
 
-        let a3 = Action::new_maintenance(&p1);
-        let a4 = Action::new_maintenance(&not_p1);
-        let a5 = Action::new_maintenance(&p2);
-        let a6 = Action::new_maintenance(&not_p2);
-
+        let actions = hashset!{&a1, &a2};
         let initial_props = hashset!{&p1, &p2};
         let goals = hashset!{&not_p1, &not_p2};
-        let actions = hashset!{&a1, &a2, &a3, &a4, &a5, &a6};
 
-        let mut pg = GraphPlan::<&str, &str>::new(
+        let domain = GraphPlan::create_domain(
             initial_props,
             goals,
-            actions
+            actions,
         );
+
+        let mut pg = GraphPlan::<&str, &str>::from_domain(&domain);
         assert!(pg.search::<SimpleSolver>() != None, "Solution should not be None");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,56 @@ mod pairset;
 //     pub fn search(&mut self) -> Option<Solution<ActionId, PropositionId>>{
 //         self.plangraph.search_with(&self.solver)
 //     }
+
+    // /// Searches the planning graph for a solution using the solver if
+    // /// there is no solution, extends the graph to depth i+1 and tries
+    // /// to solve again
+    // pub fn search_with<T>(&mut self, solver: &'a T) -> Option<Solution<'a, ActionId, PropositionId>>
+    // where T: GraphPlanSolver<'a, ActionId, PropositionId> {
+    //     let mut tries = 0;
+    //     let mut solution = None;
+    //     let max_tries = self.actions.len() + 1;
+
+    //     while tries < max_tries {
+    //         // This doesn't provide early termination for _all_
+    //         // cases that won't yield a solution.
+    //         if self.has_leveled_off() {
+    //             break;
+    //         }
+
+    //         if !self.has_possible_solution() {
+    //             debug!("No solution exists at depth {}", self.depth());
+    //             self.extend();
+    //             tries += 1;
+    //             continue
+    //         }
+
+    //         if let Some(result) = solver.search(self) {
+    //             solution = Some(result);
+    //             break;
+    //         } else {
+    //             debug!("No solution found at depth {}", self.depth());
+    //             self.extend();
+    //             tries += 1
+    //         }
+
+    //     };
+    //     solution
+    // }
+
+    // /// Takes a solution and filters out maintenance actions
+    // pub fn format_plan(solution: Solution<ActionId, PropositionId>) -> Solution<ActionId, PropositionId> {
+    //     solution.iter()
+    //         .map(|s| s.iter()
+    //              .filter(|i| match i.id {
+    //                  ActionType::Action(_) => true,
+    //                  ActionType::Maintenance(_) => false})
+    //              .cloned()
+    //              .collect())
+    //         .collect()
+    // }
+
+
 // }
 
 // impl GraphPlan<String, String, SimpleSolver> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@ pub mod solver;
 mod layer;
 mod pairset;
 
-pub use crate::proposition::Proposition;
-pub use crate::action::Action;
-pub use crate::plangraph::{PlanGraph, Solution};
-pub use crate::solver::{GraphPlanSolver, SimpleSolver};
+// pub use crate::proposition::Proposition;
+// pub use crate::action::Action;
+// pub use crate::plangraph::{PlanGraph, Solution};
+// pub use crate::solver::{GraphPlanSolver, SimpleSolver};
 
 // #[cfg(any(feature = "toml", feature = "wasm"))]
 // #[derive(Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,6 @@ impl<'a,
                goals: HashSet<&'a Proposition<PropositionId>>,
                actions: HashSet<&'a Action<'a, ActionId, PropositionId>>)
                -> GraphPlan<'a, ActionId, PropositionId> {
-        // TODO: add in negated props for initial props and each
-        // actions req/effects
         // TODO: add in maintenance actions for all props
         let plangraph = PlanGraph::new(
             initial_props,

--- a/src/pairset.rs
+++ b/src/pairset.rs
@@ -1,14 +1,19 @@
-use std::collections::{HashSet};
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
-
 
 #[derive(Debug, PartialOrd, Eq, Ord, Clone)]
 /// An unordered two element tuple that such that (a, b) == (b, a)
 pub struct PairSet<T: Ord + PartialEq + Eq + Clone>(pub T, pub T);
 
-impl <T> Hash for PairSet<T> where T: Hash + Ord + Clone{
-    fn hash<H>(&self, state: &mut H) where H: Hasher {
+impl<T> Hash for PairSet<T>
+where
+    T: Hash + Ord + Clone,
+{
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
         if self.0 < self.1 {
             self.0.hash(state);
             self.1.hash(state);
@@ -19,14 +24,20 @@ impl <T> Hash for PairSet<T> where T: Hash + Ord + Clone{
     }
 }
 
-impl <T> PartialEq for PairSet<T> where T: Ord + Clone{
+impl<T> PartialEq for PairSet<T>
+where
+    T: Ord + Clone,
+{
     fn eq(&self, other: &PairSet<T>) -> bool {
         self.0 == other.0 && self.1 == other.1 || self.1 == other.0 && self.0 == other.1
     }
 }
 
-impl<T> PairSet<T> where T: Ord + PartialEq + Eq + Clone {
-    pub fn to_owned(&self) -> PairSet<T>{
+impl<T> PairSet<T>
+where
+    T: Ord + PartialEq + Eq + Clone,
+{
+    pub fn to_owned(&self) -> PairSet<T> {
         let PairSet(a, b) = self;
         PairSet(a.to_owned(), b.to_owned())
     }
@@ -45,8 +56,8 @@ mod pair_set_test {
         );
 
         assert!(
-            !hashset!{PairSet::<&'static str>("test1", "test2")}
-            .insert(PairSet::<&'static str>("test2", "test1")),
+            !hashset! {PairSet::<&'static str>("test1", "test2")}
+                .insert(PairSet::<&'static str>("test2", "test1")),
             "Hashed value should be the same regardless of order"
         )
     }
@@ -69,9 +80,10 @@ pub fn pairs<T: Eq + Hash + Clone + Ord>(items: &HashSet<T>) -> HashSet<PairSet<
 }
 
 /// Returns the pairs of a set of items
-pub fn pairs_from_sets<T: Eq + Hash + Clone + Ord>(items1: HashSet<T>,
-                                                   items2: HashSet<T>)
-                                                   -> HashSet<PairSet<T>> {
+pub fn pairs_from_sets<T: Eq + Hash + Clone + Ord>(
+    items1: HashSet<T>,
+    items2: HashSet<T>,
+) -> HashSet<PairSet<T>> {
     let mut accum = HashSet::new();
 
     let mut sorted1 = Vec::from_iter(items1.into_iter());
@@ -102,23 +114,26 @@ mod pairs_test {
         let p2 = "b";
         let p3 = "c";
         assert_eq!(
-            hashset!{PairSet(p1.clone(), p2.clone()),
-                     PairSet(p1.clone(), p3.clone()),
-                     PairSet(p2.clone(), p3.clone())},
-            pairs(&hashset!{p1.clone(), p2.clone(), p3.clone()})
+            hashset! {PairSet(p1.clone(), p2.clone()),
+            PairSet(p1.clone(), p3.clone()),
+            PairSet(p2.clone(), p3.clone())},
+            pairs(&hashset! {p1.clone(), p2.clone(), p3.clone()})
         );
     }
 
     #[test]
     fn yields_unique_pairs_from_sets() {
-        assert_eq!(pairs_from_sets(hashset!{1, 2}, hashset!{3}),
-                   hashset!{PairSet(1, 3), PairSet(2, 3)});
+        assert_eq!(
+            pairs_from_sets(hashset! {1, 2}, hashset! {3}),
+            hashset! {PairSet(1, 3), PairSet(2, 3)}
+        );
 
-        assert_eq!(pairs_from_sets(hashset!{1}, hashset!{1, 2}),
-                   hashset!{PairSet(1, 2)});
+        assert_eq!(
+            pairs_from_sets(hashset! {1}, hashset! {1, 2}),
+            hashset! {PairSet(1, 2)}
+        );
 
-        assert_eq!(pairs_from_sets(hashset!{}, hashset!{1, 2}),
-                   hashset!{});
+        assert_eq!(pairs_from_sets(hashset! {}, hashset! {1, 2}), hashset! {});
     }
 
     #[test]
@@ -131,24 +146,24 @@ mod pairs_test {
 
         let a1 = Action::new(
             String::from("coffee"),
-            hashset!{&p1},
-            hashset!{&p3, &not_p1}
+            hashset! {&p1},
+            hashset! {&p3, &not_p1},
         );
         let a2 = Action::new(
             String::from("walk dog"),
-            hashset!{&p2, &p3},
-            hashset!{&not_p2},
+            hashset! {&p2, &p3},
+            hashset! {&not_p2},
         );
-        let a3 = Action::new_maintenance(p1.negate());
+        let a3 = Action::new_maintenance(&not_p1);
 
         assert_eq!(
-            pairs_from_sets(hashset!{a1.clone()}, hashset!{a2.clone()}),
-            hashset!{PairSet(a1.clone(), a2.clone())}
+            pairs_from_sets(hashset! {a1.clone()}, hashset! {a2.clone()}),
+            hashset! {PairSet(a1.clone(), a2.clone())}
         );
 
         assert_eq!(
-            pairs_from_sets(hashset!{a3.clone()}, hashset!{a2.clone()}),
-            hashset!{PairSet(a3, a2)}
+            pairs_from_sets(hashset! {a3.clone()}, hashset! {a2.clone()}),
+            hashset! {PairSet(a3, a2)}
         );
     }
 }

--- a/src/pairset.rs
+++ b/src/pairset.rs
@@ -102,6 +102,29 @@ pub fn pairs_from_sets<T: Eq + Hash + Clone + Ord>(
     accum
 }
 
+/// Returns the pairs of a set of items
+pub fn pairs_from_borrowed_sets<'p, T: Eq + Hash + Clone + Ord>(
+    items1: &HashSet<&'p T>,
+    items2: &HashSet<&'p T>,
+) -> HashSet<PairSet<&'p T>> {
+    let mut accum = HashSet::new();
+
+    let mut sorted1 = Vec::from_iter(items1.into_iter());
+    sorted1.sort();
+
+    let mut sorted2 = Vec::from_iter(items2.into_iter());
+    sorted2.sort();
+
+    for i in sorted1.iter() {
+        for j in sorted2.iter() {
+            if i != j {
+                accum.insert(PairSet(**i, **j));
+            }
+        }
+    }
+    accum
+}
+
 #[cfg(test)]
 mod pairs_test {
     use super::*;

--- a/src/plangraph.rs
+++ b/src/plangraph.rs
@@ -68,53 +68,15 @@ impl<'a,
             actions.to_owned()
         };
 
+        let action_layer = Layer::from_layer(
+            &actions_no_mutex_reqs,
+            &layer
+        );
 
-        // TODO: For some reason from_layer messes up lifetime
-        // inference when called this way vs inlined
-        // let action_layer = Layer::from_layer(
-        //     actions_no_mutex_reqs,
-        //     &layer
-        // );
-        let props = match layer {
-            Layer::PropositionLayer(props) => props,
-            _ => unreachable!()
-        };
-        let action_layer = {
-            let mut layer_data = ActionLayerData::new();
-
-            for a in actions_no_mutex_reqs {
-                // Include action if it satisfies one or more props
-                if a.reqs.is_subset(props) {
-                    layer_data.insert(a);
-                }
-            }
-
-            // TODO: Move creation of maintenance actions out of
-            // here otherwise it will conflict with the lifetime
-            // 'a
-            // Add in maintenance actions for all props
-            // for p in props {
-            //     layer_data.insert(Action::new_maintenance(p.to_owned()));
-            // }
-
-            Layer::ActionLayer(layer_data)
-        };
-
-        // let prop_layer = Layer::from_layer(
-        //     self.actions,
-        //     &action_layer
-        // );
-
-        let prop_layer = {
-            let mut layer_data = PropositionLayerData::new();
-            for a in actions {
-                for e in a.effects.iter() {
-                    layer_data.insert(e);
-                }
-            }
-
-            Layer::PropositionLayer(layer_data)
-        };
+        let prop_layer = Layer::from_layer(
+            &actions,
+            &action_layer
+        );
 
         let action_layer_actions = match &action_layer {
             Layer::ActionLayer(action_data) => action_data,

--- a/src/plangraph.rs
+++ b/src/plangraph.rs
@@ -1,11 +1,9 @@
 use std::fmt::{Debug, Display};
 use std::collections::{HashMap, HashSet, BTreeSet};
 use std::hash::Hash;
-use log::{debug};
 use crate::proposition::Proposition;
-use crate::action::{Action, ActionType};
-use crate::pairset::{pairs, PairSet};
-use crate::solver::GraphPlanSolver;
+use crate::action::Action;
+use crate::pairset::pairs;
 use crate::layer::{Layer, MutexPairs, ActionLayerData, PropositionLayerData};
 
 
@@ -46,7 +44,7 @@ impl<'a,
 
     /// Extends the plangraph to depth i+1
     /// Inserts another action layer and proposition layer
-    pub fn extend(&mut self) {
+    pub fn extend(&mut self) -> &mut Self {
         let layers = &self.layers;
         let actions = &self.actions;
         let length = layers.len();
@@ -143,6 +141,8 @@ impl<'a,
         self.mutex_props.insert(length, prop_mutexes);
         self.layers.push(action_layer);
         self.layers.push(prop_layer);
+
+        self
     }
 
     /// Returns the depth of the planning graph
@@ -155,7 +155,7 @@ impl<'a,
     }
 
     // Returns the actions at layer index as an ordered set
-    pub fn actions_at_layer(&self, index: usize) -> Result<BTreeSet<&Action<ActionId, PropositionId>>, String> {
+    pub fn actions_at_layer(&self, index: usize) -> Result<BTreeSet<&'a Action<ActionId, PropositionId>>, String> {
         self.layers.get(index).map_or(
             Err(format!("Layer {} does not exist", index)),
             |layer| {
@@ -178,7 +178,7 @@ impl<'a,
 
     /// A solution is possible if all goals exist in the last
     /// proposition layer and are not mutex
-    fn has_possible_solution(&self) -> bool {
+    pub fn has_possible_solution(&self) -> bool {
         let goals = self.goals.clone();
         let last_layer_idx = self.layers.clone().len() - 1;
 
@@ -205,7 +205,7 @@ impl<'a,
 
     /// The graph is considered to have "leveled off" when proposition
     /// layer P and an adjacent proposition layer Q are equal
-    fn has_leveled_off(&self) -> bool {
+    pub fn has_leveled_off(&self) -> bool {
         let len = self.layers.len();
         if len > 2 as usize {
             let prop_layer = self.layers.get(len - 1).expect("Failed to get layer");

--- a/src/plangraph.rs
+++ b/src/plangraph.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use crate::proposition::Proposition;
 use crate::action::Action;
 use crate::pairset::pairs;
-use crate::layer::{Layer, MutexPairs, ActionLayerData, PropositionLayerData};
+use crate::layer::{Layer, MutexPairs};
 
 
 type LayerNumber = usize;

--- a/src/plangraph.rs
+++ b/src/plangraph.rs
@@ -120,7 +120,7 @@ impl<'a,
     /// proposition layer and are not mutex
     pub fn has_possible_solution(&self) -> bool {
         let goals = self.goals.clone();
-        let last_layer_idx = self.layers.clone().len() - 1;
+        let last_layer_idx = self.layers.len() - 1;
 
         if let Some(prop_layer) = self.layers.get(last_layer_idx) {
             match prop_layer {

--- a/src/plangraph.rs
+++ b/src/plangraph.rs
@@ -1,5 +1,5 @@
 use std::fmt::{Debug, Display};
-use std::collections::{HashMap, HashSet, BTreeSet};
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use crate::proposition::Proposition;
 use crate::action::Action;
@@ -114,28 +114,6 @@ impl<'a,
         } else {
             0
         }
-    }
-
-    // Returns the actions at layer index as an ordered set
-    pub fn actions_at_layer(&self, index: usize) -> Result<BTreeSet<&'a Action<ActionId, PropositionId>>, String> {
-        self.layers.get(index).map_or(
-            Err(format!("Layer {} does not exist", index)),
-            |layer| {
-                match layer {
-                    Layer::ActionLayer(actions) => {
-                        let acts = actions
-                           .iter()
-                           .cloned()
-                           .collect::<BTreeSet<_>>();
-                        Ok(acts)
-                    },
-                    Layer::PropositionLayer(_) => {
-                        Err(format!("Tried to get actions from proposition layer {}",
-                                    index))
-                    }
-                }
-            }
-        )
     }
 
     /// A solution is possible if all goals exist in the last

--- a/src/plangraph.rs
+++ b/src/plangraph.rs
@@ -10,7 +10,7 @@ use crate::layer::{Layer, MutexPairs, ActionLayerData, PropositionLayerData};
 
 
 type LayerNumber = usize;
-pub type Solution<'a, ActionId, PropositionId> = Vec<HashSet<Action<'a, ActionId, PropositionId>>>;
+pub type Solution<'a, ActionId, PropositionId> = Vec<HashSet<&'a Action<'a, ActionId, PropositionId>>>;
 
 #[derive(Debug)]
 pub struct PlanGraph<'a,
@@ -214,50 +214,5 @@ impl<'a,
         } else {
             false
         }
-    }
-
-    /// Searches the planning graph for a solution using the solver if
-    /// there is no solution, extends the graph to depth i+1 and tries
-    /// to solve again
-    pub fn search_with<T>(&mut self, solver: &'a T) -> Option<Solution<'a, ActionId, PropositionId>>
-    where T: GraphPlanSolver<ActionId, PropositionId> {
-        let mut tries = 0;
-        let mut solution = None;
-        let max_tries = self.actions.len() + 1;
-
-        while tries < max_tries {
-            // This doesn't provide early termination for _all_
-            // cases that won't yield a solution.
-            if self.has_leveled_off() {
-                break;
-            }
-            if self.has_possible_solution() {
-                if let Some(s) = solver.search(self) {
-                    solution = Some(s);
-                    break;
-                } else {
-                    debug!("No solution found at depth {}", self.depth());
-                    self.extend();
-                    tries += 1
-                }
-            } else {
-                debug!("No solution exists at depth {}", self.depth());
-                self.extend();
-                tries += 1;
-            }
-        };
-        solution
-    }
-
-    /// Takes a solution and filters out maintenance actions
-    pub fn format_plan(solution: Solution<ActionId, PropositionId>) -> Solution<ActionId, PropositionId> {
-        solution.iter()
-            .map(|s| s.iter()
-                 .filter(|i| match i.id {
-                     ActionType::Action(_) => true,
-                     ActionType::Maintenance(_) => false})
-                 .cloned()
-                 .collect())
-            .collect()
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -355,7 +355,7 @@ impl<'a,
             }
 
             // Note: This is a btreeset so ordering is guaranteed
-            // TODO: why doesn't it work when calling PlanGraph.actions_at_layer
+            // which makes the plans yielded deterministic
             let actions = plangraph.layers.get(idx - 1).map_or(
                 Err(format!("Layer {} does not exist", idx - 1)),
                 |layer| {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -11,461 +11,479 @@ use crate::layer::{MutexPairs};
 use crate::plangraph::{PlanGraph, Solution};
 
 
-pub trait GraphPlanSolver<ActionId: Hash + Ord + Clone + Debug,
+pub trait GraphPlanSolver<'a,
+                          ActionId: Hash + Ord + Clone + Debug,
                           PropositionId: Hash + Ord + Clone + Debug + Display> {
     /// Searches a plangraph for a sequence of collection of actions
     /// that satisfy the goals
-    fn search(&self, plangraph: &PlanGraph<ActionId, PropositionId>) -> Option<Solution<ActionId, PropositionId>>;
+    fn search(&self, plangraph: &'a PlanGraph<ActionId, PropositionId>) -> Option<Solution<'a, ActionId, PropositionId>>;
 }
 
-// #[derive(Default)]
-// pub struct SimpleSolver;
+#[derive(Default)]
+pub struct SimpleSolver;
 
-// type GoalIndex = usize;
-// type Attempts<ActionId, PropositionId> = HashMap<usize, BTreeSet<Action<ActionId, PropositionId>>>;
+type GoalIndex = usize;
+type Attempts<'a, ActionId, PropositionId> = HashMap<usize, BTreeSet<&'a Action<'a, ActionId, PropositionId>>>;
 
-// #[derive(Clone, Debug, PartialEq)]
-// struct ActionCombination<ActionId: Hash + PartialEq + Clone + Debug ,
-//                          PropositionId: Hash + Eq + PartialEq + Clone + Debug + Display>(
-//     HashMap<GoalIndex, Action<ActionId, PropositionId>>
-// );
+#[derive(Clone, Debug, PartialEq)]
+struct ActionCombination<'a,
+                         ActionId: Hash + PartialEq + Clone + Debug ,
+                         PropositionId: Hash + Eq + PartialEq + Clone + Debug + Display>(
+    HashMap<GoalIndex, &'a Action<'a, ActionId, PropositionId>>
+);
 
-// impl<ActionId: Clone + Hash + Eq + Debug,
-//      PropositionId: Clone + Hash + Eq + Debug + Display>
-//     ActionCombination<ActionId, PropositionId> {
-//     pub fn as_set(&self) -> HashSet<Action<ActionId, PropositionId>> {
-//         self.0.values()
-//             .cloned()
-//             .collect()
-//     }
+impl<'a,
+     ActionId: Clone + Hash + Eq + Debug,
+     PropositionId: Clone + Hash + Eq + Debug + Display>
+    ActionCombination<'a, ActionId, PropositionId> {
+    pub fn as_set(&self) -> HashSet<&'a Action<ActionId, PropositionId>> {
+        self.0.values().into_iter().map(|i| *i).collect()
+    }
 
-//     #[allow(dead_code)]
-//     pub fn as_vec(&self) -> Vec<Action<ActionId, PropositionId>> {
-//         self.0.values()
-//             .cloned()
-//             .collect()
-//     }
-// }
+    #[allow(dead_code)]
+    pub fn as_vec(&self) -> Vec<&'a Action<ActionId, PropositionId>> {
+        self.0.values().into_iter().map(|i| *i).collect()
+    }
+}
 
-// #[derive(Clone, Debug)]
-// struct GoalSetActionGenerator<ActionId: Debug + Hash + Clone + Eq + Ord,
-//                               PropositionId: Debug + Display + Hash + Clone + Eq + Ord> {
-//     goals: Vec<Proposition<PropositionId>>,
-//     actions: BTreeSet<Action<ActionId, PropositionId>>,
-//     mutexes: Option<MutexPairs<Action<ActionId, PropositionId>>>,
-// }
+#[derive(Clone, Debug)]
+struct GoalSetActionGenerator<'a,
+                              ActionId: Debug + Hash + Clone + Eq + Ord,
+                              PropositionId: Debug + Display + Hash + Clone + Eq + Ord> {
+    goals: Vec<&'a Proposition<PropositionId>>,
+    actions: BTreeSet<&'a Action<'a, ActionId, PropositionId>>,
+    mutexes: Option<MutexPairs<&'a Action<'a, ActionId, PropositionId>>>,
+}
 
-// impl<ActionId: Ord + Clone + Hash + Debug,
-//      PropositionId: Ord + Clone + Hash + Debug + Display>
-//     GoalSetActionGenerator<ActionId, PropositionId> {
-//     pub fn new(goals: Vec<Proposition<PropositionId>>,
-//                actions: BTreeSet<Action<ActionId, PropositionId>>,
-//                mutexes: Option<MutexPairs<Action<ActionId, PropositionId>>>,)
-//                -> GoalSetActionGenerator<ActionId, PropositionId> {
-//         GoalSetActionGenerator {goals, actions, mutexes}
-//     }
-// }
+impl<'a,
+     ActionId: Ord + Clone + Hash + Debug,
+     PropositionId: Ord + Clone + Hash + Debug + Display>
+    GoalSetActionGenerator<'a, ActionId, PropositionId> {
+    pub fn new(goals: Vec<&'a Proposition<PropositionId>>,
+               actions: BTreeSet<&'a Action<'a, ActionId, PropositionId>>,
+               mutexes: Option<MutexPairs<&'a Action<'a, ActionId, PropositionId>>>,)
+               -> GoalSetActionGenerator<'a, ActionId, PropositionId> {
+        GoalSetActionGenerator {goals, actions, mutexes}
+    }
+}
 
-// impl<ActionId: Ord + Clone + Hash + Debug,
-//      PropositionId: Ord + Clone + Hash + Debug + Display>
-//     IntoIterator for GoalSetActionGenerator<ActionId, PropositionId> {
-//     type Item = ActionCombination<ActionId, PropositionId>;
-//     type IntoIter = ActionCombinationIterator<ActionId, PropositionId>;
+impl<'a,
+     ActionId: Ord + Clone + Hash + Debug,
+     PropositionId: Ord + Clone + Hash + Debug + Display>
+    IntoIterator for GoalSetActionGenerator<'a, ActionId, PropositionId> {
+    type Item = ActionCombination<'a, ActionId, PropositionId>;
+    type IntoIter = ActionCombinationIterator<'a, ActionId, PropositionId>;
 
-//     fn into_iter(self) -> Self::IntoIter {
-//         ActionCombinationIterator::new(self)
-//     }
-// }
+    fn into_iter(self) -> Self::IntoIter {
+        ActionCombinationIterator::new(self)
+    }
+}
 
-// #[derive(Clone, Debug)]
-// struct ActionCombinationIterator<ActionId: Ord + Clone + Hash + Debug,
-//                                  PropositionId: Ord + Clone + Hash + Debug + Display> {
-//     meta: GoalSetActionGenerator<ActionId, PropositionId>, // defines goals we are trying achieve
-//     attempts: Attempts<ActionId, PropositionId>, // previous attempts to meet a goal
-//     goals_met: bool, // flag indicating all goals are met or restart
-//     accum: HashMap<GoalIndex, Action<ActionId, PropositionId>> // combination of actions
-// }
+#[derive(Clone, Debug)]
+struct ActionCombinationIterator<'a,
+                                 ActionId: Ord + Clone + Hash + Debug,
+                                 PropositionId: Ord + Clone + Hash + Debug + Display> {
+    meta: GoalSetActionGenerator<'a, ActionId, PropositionId>, // defines goals we are trying achieve
+    attempts: Attempts<'a, ActionId, PropositionId>, // previous attempts to meet a goal
+    goals_met: bool, // flag indicating all goals are met or restart
+    accum: HashMap<GoalIndex, &'a Action<'a, ActionId, PropositionId>> // combination of actions
+}
 
-// impl<ActionId: Ord + Debug + Hash + Clone,
-//      PropositionId: Ord + Debug + Display + Hash + Clone>
-//     ActionCombinationIterator<ActionId, PropositionId> {
-//     pub fn new(action_combinations: GoalSetActionGenerator<ActionId, PropositionId>) -> ActionCombinationIterator<ActionId, PropositionId> {
-//         ActionCombinationIterator {
-//             meta: action_combinations,
-//             attempts: Attempts::new(),
-//             goals_met: false,
-//             accum: HashMap::new(),
-//         }
-//     }
-// }
+impl<'a,
+     ActionId: Ord + Debug + Hash + Clone,
+     PropositionId: Ord + Debug + Display + Hash + Clone>
+    ActionCombinationIterator<'a, ActionId, PropositionId> {
+    pub fn new(action_combinations: GoalSetActionGenerator<ActionId, PropositionId>) -> ActionCombinationIterator<ActionId, PropositionId> {
+        ActionCombinationIterator {
+            meta: action_combinations,
+            attempts: Attempts::new(),
+            goals_met: false,
+            accum: HashMap::new(),
+        }
+    }
+}
 
-// impl<ActionId: Ord + Clone + Hash + Debug + PartialEq,
-//      PropositionId: Ord + Clone + Hash + Debug + Display + PartialEq>
-//     Iterator for ActionCombinationIterator<ActionId, PropositionId> {
-//     type Item = ActionCombination<ActionId, PropositionId>;
+impl<'a,
+     ActionId: Ord + Clone + Hash + Debug + PartialEq,
+     PropositionId: Ord + Clone + Hash + Debug + Display + PartialEq>
+    Iterator for ActionCombinationIterator<'a, ActionId, PropositionId> {
+    type Item = ActionCombination<'a, ActionId, PropositionId>;
 
-//     fn next(&mut self) -> Option<Self::Item> {
-//         let goals = &self.meta.goals;
-//         let actions = &self.meta.actions;
-//         let goal_len = goals.len();
+    fn next(&mut self) -> Option<Self::Item> {
+        let goals = &self.meta.goals;
+        let actions = &self.meta.actions;
+        let goal_len = goals.len();
 
-//         let mut stack = VecDeque::new();
+        let mut stack = VecDeque::new();
 
-//         // If the goals have already been met, we need to look for a
-//         // new combination that also meets the goals
-//         if self.goals_met {
-//             // Remove the previous action used to satisfy the last
-//             // goal and start the loop from the last goal. This will
-//             // yield a new combination or recursively back track.
-//             self.goals_met = false;
-//             let goal_idx = goal_len - 1;
-//             self.accum.remove(&goal_idx);
-//             stack.push_front(goal_idx);
-//         } else {
-//             stack.push_front(0);
-//         }
+        // If the goals have already been met, we need to look for a
+        // new combination that also meets the goals
+        if self.goals_met {
+            // Remove the previous action used to satisfy the last
+            // goal and start the loop from the last goal. This will
+            // yield a new combination or recursively back track.
+            self.goals_met = false;
+            let goal_idx = goal_len - 1;
+            self.accum.remove(&goal_idx);
+            stack.push_front(goal_idx);
+        } else {
+            stack.push_front(0);
+        }
 
-//         while let Some(goal_idx) = stack.pop_front() {
-//             let available_actions = if let Some(acts) = self.attempts.get(&goal_idx) {
-//                 acts.to_owned()
-//             } else {
-//                 let goal = &goals[goal_idx];
-//                 debug!("Working on goal {:?}", goal);
-//                 let mut available = BTreeSet::new();
-//                 // Only actions that produce the goal and are not
-//                 // mutex with any other actions and have not
-//                 // already been attempted in combination with the
-//                 // other attempted actions and are not mutex with
-//                 // any other action
-//                 for a in actions {
-//                     // Early continue since the later checks are
-//                     // more expensive
-//                     if !a.effects.contains(goal) {
-//                         continue
-//                     };
+        while let Some(goal_idx) = stack.pop_front() {
+            let available_actions = if let Some(acts) = self.attempts.get(&goal_idx) {
+                acts.to_owned()
+            } else {
+                let goal = &goals[goal_idx];
+                debug!("Working on goal {:?}", goal);
+                let mut available = BTreeSet::new();
+                // Only actions that produce the goal and are not
+                // mutex with any other actions and have not
+                // already been attempted in combination with the
+                // other attempted actions and are not mutex with
+                // any other action
+                for a in actions {
+                    // Early continue since the later checks are
+                    // more expensive
+                    if !a.effects.contains(goal) {
+                        continue
+                    };
 
-//                     // Early break if we already know this action
-//                     // works for the goal from previous attempts
-//                     if self.accum.get(&goal_idx).map(|i| i == a).unwrap_or(false) {
-//                         available.insert(a.clone());
-//                         break
-//                     };
+                    // Early break if we already know this action
+                    // works for the goal from previous attempts
+                    if self.accum.get(&goal_idx).map(|i| i == a).unwrap_or(false) {
+                        available.insert(a.clone());
+                        break
+                    };
 
-//                     // Check if this action is mutex with any of
-//                     // the other accumulated actions
-//                     let acts = self.accum.clone();
-//                     let pairs = pairs_from_sets(
-//                         hashset!{a.clone()},
-//                         ActionCombination(acts).as_set()
-//                     );
-//                     debug!("Checking pairs: {:?} against mutexes: {:?}", pairs, &self.meta.mutexes);
+                    // Check if this action is mutex with any of
+                    // the other accumulated actions
+                    let acts = self.accum.clone();
+                    let pairs = pairs_from_sets(
+                        hashset!{*a},
+                        acts.values().into_iter().map(|i| *i).collect()
+                    );
+                    debug!("Checking pairs: {:?} against mutexes: {:?}", &pairs, &self.meta.mutexes);
 
-//                     if let Some(muxes) = &self.meta.mutexes {
-//                         if muxes.intersection(&pairs).next().is_none() {
-//                             available.insert(a.clone());
-//                         }
-//                     };
-//                 };
-//                 available
-//             };
+                    if let Some(muxes) = &self.meta.mutexes {
+                        if muxes.intersection(&pairs).next().is_none() {
+                            available.insert(a.clone());
+                        }
+                    };
+                };
+                available
+            };
 
-//             if available_actions.is_empty() {
-//                 if goal_idx == 0 {
-//                     // Complete fail
-//                     break;
-//                 }
-//                 debug!("Unable to find actions for goal {:?}. Going back to previous goal...", goal_idx);
-//                 // Clear attempts for this goal so finding an action
-//                 // can be retried with a new set of actions
-//                 self.attempts.remove(&goal_idx);
-//                 // Backtrack to the previous goal
-//                 stack.push_front(goal_idx - 1);
-//             } else {
-//                 let next_action = available_actions.iter().next().unwrap();
-//                 // TODO only add the action if the goal isn't met yet
-//                 self.accum.insert(goal_idx, next_action.clone());
+            if available_actions.is_empty() {
+                if goal_idx == 0 {
+                    // Complete fail
+                    break;
+                }
+                debug!("Unable to find actions for goal {:?}. Going back to previous goal...", goal_idx);
+                // Clear attempts for this goal so finding an action
+                // can be retried with a new set of actions
+                self.attempts.remove(&goal_idx);
+                // Backtrack to the previous goal
+                stack.push_front(goal_idx - 1);
+            } else {
+                let next_action = available_actions.iter().next().unwrap();
+                // TODO only add the action if the goal isn't met yet
+                self.accum.insert(goal_idx, next_action.clone());
 
-//                 // Add to previous attempts in case we need to backtrack
-//                 let mut remaining_actions = available_actions.clone();
-//                 remaining_actions.remove(&next_action);
-//                 self.attempts.insert(goal_idx, remaining_actions);
+                // Add to previous attempts in case we need to backtrack
+                let mut remaining_actions = available_actions.clone();
+                remaining_actions.remove(next_action);
+                self.attempts.insert(goal_idx, remaining_actions);
 
-//                 // TODO Implement minimal action sets i.e handle if
-//                 // this action staisfies more than one
-//                 // goal. Otherwise, the speed of finding a solution is
-//                 // dependent on the ordering of goals
-//                 // From the paper: no action can be
-//                 // removed from A so that the add effects of the
-//                 // actions remaining still contain G
+                // TODO Implement minimal action sets i.e handle if
+                // this action staisfies more than one
+                // goal. Otherwise, the speed of finding a solution is
+                // dependent on the ordering of goals
+                // From the paper: no action can be
+                // removed from A so that the add effects of the
+                // actions remaining still contain G
 
-//                 // Proceed to the next goal
-//                 if goal_idx < goal_len - 1 {
-//                     stack.push_front(goal_idx + 1);
-//                 } else {
-//                     self.goals_met = true;
-//                 }
-//             };
-//         };
+                // Proceed to the next goal
+                if goal_idx < goal_len - 1 {
+                    stack.push_front(goal_idx + 1);
+                } else {
+                    self.goals_met = true;
+                }
+            };
+        };
 
-//         if self.goals_met {
-//             Some(ActionCombination(self.accum.clone()))
-//         } else {
-//             None
-//         }
-//     }
-// }
+        if self.goals_met {
+            Some(ActionCombination(self.accum.clone()))
+        } else {
+            None
+        }
+    }
+}
 
 
-// #[cfg(test)]
-// mod goal_set_action_generator_test {
-//     use super::*;
+#[cfg(test)]
+mod goal_set_action_generator_test {
+    use super::*;
 
-//     #[test]
-//     fn single_goal() {
-//         let p1 = Proposition::from("coffee");
-//         let p2 = Proposition::from("caffeinated");
-//         let goals = vec![p2.clone()];
-//         let mut actions = BTreeSet::new();
-//         let a1 = Action::new(
-//             String::from("drink coffee"),
-//             hashset!{&p1},
-//             hashset!{&p2}
-//         );
-//         actions.insert(a1.clone());
-//         let mutexes = Some(MutexPairs::new());
-//         let expected = ActionCombination(hashmap!{0 => a1});
-//         let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
-//             .into_iter()
-//             .next()
-//             .unwrap();
-//         assert_eq!(expected, actual);
-//     }
+    #[test]
+    fn single_goal() {
+        let p1 = Proposition::from("coffee");
+        let p2 = Proposition::from("caffeinated");
+        let goals = vec![&p2];
 
-//     #[test]
-//     fn multiple_goals() {
-//         let p1 = Proposition::from("coffee");
-//         let p2 = Proposition::from("caffeinated");
-//         let p3 = Proposition::from("breakfast");
-//         let p4 = Proposition::from("full");
-//         let goals = vec![p2.clone(), p4.clone()];
-//         let mut actions = BTreeSet::new();
-//         let a1 = Action::new(
-//             String::from("drink coffee"),
-//             hashset!{&p1},
-//             hashset!{&p2}
-//         );
-//         actions.insert(a1.clone());
+        let mut actions = BTreeSet::new();
+        let a1 = Action::new(
+            String::from("drink coffee"),
+            hashset!{&p1},
+            hashset!{&p2}
+        );
+        actions.insert(&a1);
 
-//         let a2 = Action::new(
-//             String::from("eat breakfast"),
-//             hashset!{&p3},
-//             hashset!{&p4}
-//         );
-//         actions.insert(a2.clone());
+        let mutexes = Some(MutexPairs::new());
+        let expected = ActionCombination(hashmap!{0usize => &a1});
+        let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(expected, actual);
+    }
 
-//         let mutexes = Some(MutexPairs::new());
-//         let expected = ActionCombination(hashmap!{0 => a1.clone(), 1 => a2.clone()});
-//         let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
-//             .into_iter()
-//             .next()
-//             .unwrap();
-//         assert_eq!(expected, actual);
-//     }
+    #[test]
+    fn multiple_goals() {
+        let p1 = Proposition::from("coffee");
+        let p2 = Proposition::from("caffeinated");
+        let p3 = Proposition::from("breakfast");
+        let p4 = Proposition::from("full");
+        let goals = vec![&p2, &p4];
+        let mut actions = BTreeSet::new();
+        let a1 = Action::new(
+            String::from("drink coffee"),
+            hashset!{&p1},
+            hashset!{&p2}
+        );
+        actions.insert(&a1);
 
-//     #[test]
-//     fn yields_all() {
-//         let p1 = Proposition::from("tea");
-//         let p2 = Proposition::from("coffee");
-//         let p3 = Proposition::from("caffeinated");
-//         let p4 = Proposition::from("scone");
-//         let p5 = Proposition::from("muffin");
-//         let p6 = Proposition::from("full");
-//         let goals = vec![p3.clone(), p6.clone()];
-//         let mut actions = BTreeSet::new();
+        let a2 = Action::new(
+            String::from("eat breakfast"),
+            hashset!{&p3},
+            hashset!{&p4}
+        );
+        actions.insert(&a2);
 
-//         let a1 = Action::new(
-//             String::from("drink coffee"),
-//             hashset!{&p2},
-//             hashset!{&p3}
-//         );
-//         actions.insert(a1.clone());
+        let mutexes = Some(MutexPairs::new());
+        let expected = ActionCombination(hashmap!{0usize => &a1, 1usize => &a2});
+        let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(expected, actual);
+    }
 
-//         let a2 = Action::new(
-//             String::from("drink tea"),
-//             hashset!{&p1},
-//             hashset!{&p3}
-//         );
-//         actions.insert(a2.clone());
+    #[test]
+    fn yields_all() {
+        let p1 = Proposition::from("tea");
+        let p2 = Proposition::from("coffee");
+        let p3 = Proposition::from("caffeinated");
+        let p4 = Proposition::from("scone");
+        let p5 = Proposition::from("muffin");
+        let p6 = Proposition::from("full");
+        let goals = vec![&p3, &p6];
+        let mut actions = BTreeSet::new();
 
-//         let a3 = Action::new(
-//             String::from("eat scone"),
-//             hashset!{&p4},
-//             hashset!{&p6}
-//         );
-//         actions.insert(a3.clone());
+        let a1 = Action::new(
+            "drink coffee",
+            hashset!{&p2},
+            hashset!{&p3}
+        );
+        actions.insert(&a1);
 
-//         let a4 = Action::new(
-//             String::from("eat muffin"),
-//             hashset!{&p5},
-//             hashset!{&p6}
-//         );
-//         actions.insert(a4.clone());
+        let a2 = Action::new(
+            "drink tea",
+            hashset!{&p1},
+            hashset!{&p3}
+        );
+        actions.insert(&a2);
 
-//         let mutexes = Some(MutexPairs::new());
-//         let expected = vec![
-//             vec![a1.clone(), a4.clone()],
-//             vec![a1.clone(), a3.clone()],
-//             vec![a2.clone(), a4.clone()],
-//             vec![a2.clone(), a3.clone()],
-//         ];
-//         let generator = GoalSetActionGenerator::new(goals, actions, mutexes);
-//         let actual: Vec<Vec<Action<_, _>>> = generator.into_iter()
-//             .map(|combo| {let mut i = combo.as_vec(); i.sort(); i})
-//             .collect();
+        let a3 = Action::new(
+            "eat scone",
+            hashset!{&p4},
+            hashset!{&p6}
+        );
+        actions.insert(&a3);
 
-//         assert_eq!(expected, actual);
-//     }
-// }
+        let a4 = Action::new(
+            "eat muffin",
+            hashset!{&p5},
+            hashset!{&p6}
+        );
+        actions.insert(&a4);
 
-// type SearchStack<ActionId, PropositionId> = VecDeque<(usize, Vec<Proposition<PropositionId>>, Option<ActionCombinationIterator<ActionId, PropositionId>>)>;
+        let mutexes = Some(MutexPairs::new());
+        let expected = vec![
+            vec![&a1, &a4],
+            vec![&a1, &a3],
+            vec![&a2, &a4],
+            vec![&a2, &a3],
+        ];
+        let generator = GoalSetActionGenerator::new(goals, actions, mutexes);
+        let actual: Vec<Vec<&Action<_, _>>> = generator.into_iter()
+            .map(|combo| {
+                let mut out = combo.0.values()
+                    .into_iter()
+                    .map(|i| *i)
+                    .collect::<Vec<&Action<&str, &str>>>();
+                out.sort();
+                out
+            })
+            .collect();
 
-// impl<ActionId: Ord + Clone + Hash + Debug,
-//      PropositionId: Ord + Clone + Hash + Debug + Display>
-//     GraphPlanSolver<ActionId, PropositionId> for SimpleSolver {
-//     fn search(&self, plangraph: &PlanGraph<ActionId, PropositionId>) -> Option<Solution<ActionId, PropositionId>> {
-//         let mut success = false;
-//         let mut plan = Vec::new();
-//         let mut failed_goals_memo: HashSet<(usize, Vec<Proposition<PropositionId>>)> = HashSet::new();
+        assert_eq!(expected, actual);
+    }
+}
 
-//         // Initialize the loop
-//         let mut stack: SearchStack<ActionId, PropositionId> = VecDeque::new();
-//         let init_goals = Vec::from_iter(plangraph.goals.clone());
-//         let init_layer_idx = plangraph.layers.len() - 1;
-//         let init_action_gen = None;
+type SearchStack<'a, ActionId, PropositionId> = VecDeque<(usize, Vec<&'a Proposition<PropositionId>>, Option<ActionCombinationIterator<'a, ActionId, PropositionId>>)>;
 
-//         stack.push_front((init_layer_idx, init_goals, init_action_gen));
+impl<'a,
+     ActionId: Ord + Clone + Hash + Debug,
+     PropositionId: Ord + Clone + Hash + Debug + Display>
+    GraphPlanSolver<'a, ActionId, PropositionId> for SimpleSolver {
+    fn search(&self, plangraph: &'a PlanGraph<ActionId, PropositionId>) -> Option<Solution<'a, ActionId, PropositionId>> {
+        let mut success = false;
+        let mut plan = Vec::new();
+        let mut failed_goals_memo: HashSet<(usize, Vec<&Proposition<PropositionId>>)> = HashSet::new();
 
-//         while let Some((idx, goals, action_gen)) = stack.pop_front() {
-//             debug!("Working on layer {:?} with goals {:?}", idx, goals);
-//             // Check if the goal set is unsolvable at level idx
-//             if failed_goals_memo.contains(&(idx, goals.clone())) {
-//                 // Continue to previous layer (the next element in the queue)
-//                 continue;
-//             }
+        // Initialize the loop
+        let mut stack: SearchStack<ActionId, PropositionId> = VecDeque::new();
+        let init_goals = Vec::from_iter(plangraph.goals.clone());
+        let init_layer_idx = plangraph.layers.len() - 1;
+        let init_action_gen = None;
 
-//             // Note: This is a btreeset so ordering is guaranteed
-//             let actions = plangraph.actions_at_layer(idx - 1)
-//                 .expect("Failed to get actions");
-//             let mutexes = plangraph.mutex_actions.get(&(idx - 1)).cloned();
-//             let mut gen = action_gen
-//                 .or_else(|| Some(GoalSetActionGenerator::new(goals.clone(),
-//                                                              actions.clone(),
-//                                                              mutexes).into_iter()))
-//                 .unwrap();
+        stack.push_front((init_layer_idx, init_goals, init_action_gen));
 
-//             if let Some(goal_actions) = gen.next() {
-//                 debug!("Actions: {:?} for goals: {:?}", goal_actions.as_set(), goals);
-//                 // If we are are on the second to last proposition
-//                 // layer, we are done
-//                 if (idx - 2) == 0 {
-//                     plan.push(goal_actions.as_set());
-//                     debug!("Found plan! {:?}", plan);
-//                     success = true;
-//                     break;
-//                 } else {
-//                     plan.push(goal_actions.as_set());
-//                     let next_goals = goal_actions.as_set().into_iter()
-//                         .flat_map(|action| action.reqs)
-//                         .unique()
-//                         .collect();
-//                     // Add this layer back into the queue incase we need to backtrack
-//                     stack.push_front((idx, goals, Some(gen)));
-//                     stack.push_front((idx - 2, next_goals, None));
-//                 };
-//             } else {
-//                 debug!("Unable to find actions for goals {:?} from actions {:?}",
-//                        goals, actions);
-//                 // Record the failed goals at level idx
-//                 failed_goals_memo.insert((idx, goals.clone()));
-//                 // Remove the last step in the plan from which this
-//                 // set of goals comes from
-//                 plan.pop();
-//                 // Backtrack to previous layer and goalset or nothing
-//                 // (the next element in the queue)
-//             }
-//         };
+        while let Some((idx, goals, action_gen)) = stack.pop_front() {
+            debug!("Working on layer {:?} with goals {:?}", idx, goals);
+            // Check if the goal set is unsolvable at level idx
+            if failed_goals_memo.contains(&(idx, goals.clone())) {
+                // Continue to previous layer (the next element in the queue)
+                continue;
+            }
 
-//         if success {
-//             // Since this solver goes from the last layer to the
-//             // first, we need to reverse the plan
-//             plan.reverse();
-//             Some(plan)
-//         } else {
-//             None
-//         }
-//     }
-// }
+            // Note: This is a btreeset so ordering is guaranteed
+            let actions = plangraph.actions_at_layer(idx - 1)
+                .expect("Failed to get actions");
+            let mutexes = plangraph.mutex_actions.get(&(idx - 1)).cloned();
+            let mut gen = action_gen
+                .or_else(|| Some(GoalSetActionGenerator::new(goals.clone(),
+                                                             actions.clone(),
+                                                             mutexes).into_iter()))
+                .unwrap();
 
-// #[cfg(test)]
-// mod simple_solver_test {
-//     use super::*;
+            if let Some(goal_actions) = gen.next() {
+                debug!("Actions: {:?} for goals: {:?}", goal_actions.as_set(), goals);
+                // If we are are on the second to last proposition
+                // layer, we are done
 
-//     #[test]
-//     fn solver_works() {
-//         let p1 = Proposition::from("tired");
-//         let not_p1 = p1.negate();
-//         let p2 = Proposition::from("dog needs to pee");
-//         let not_p2 = p2.negate();
+                let goal_action_set = goal_actions.0.values()
+                    .into_iter()
+                    .map(|i| *i)
+                    .collect::<HashSet<&'a Action<ActionId, PropositionId>>>();
+                if (idx - 2) == 0 {
+                    plan.push(goal_action_set);
+                    debug!("Found plan! {:?}", plan);
+                    success = true;
+                    break;
+                } else {
+                    let next_goals = goal_action_set.iter()
+                        .flat_map(|action| action.reqs.clone())
+                        .unique()
+                        .collect();
 
-//         let a1 = Action::new(
-//             String::from("coffee"),
-//             hashset!{&p1},
-//             hashset!{&not_p1}
-//         );
+                    plan.push(goal_action_set);
+                    // Add this layer back into the queue incase we need to backtrack
+                    stack.push_front((idx, goals, Some(gen)));
+                    stack.push_front((idx - 2, next_goals, None));
+                };
+            } else {
+                debug!("Unable to find actions for goals {:?} from actions {:?}",
+                       goals, actions);
+                // Record the failed goals at level idx
+                failed_goals_memo.insert((idx, goals.clone()));
+                // Remove the last step in the plan from which this
+                // set of goals comes from
+                plan.pop();
+                // Backtrack to previous layer and goalset or nothing
+                // (the next element in the queue)
+            }
+        };
 
-//         let a2 = Action::new(
-//             String::from("walk dog"),
-//             hashset!{&p2, &not_p1},
-//             hashset!{&not_p2},
-//         );
+        if success {
+            // Since this solver goes from the last layer to the
+            // first, we need to reverse the plan
+            plan.reverse();
+            Some(plan)
+        } else {
+            None
+        }
+    }
+}
 
-//         let goals = hashset!{not_p1, not_p2};
+#[cfg(test)]
+mod simple_solver_test {
+    use super::*;
 
-//         let mut pg = PlanGraph::new(
-//             hashset!{p1, p2},
-//             goals,
-//             hashset!{a1.clone(), a2.clone()}
-//         );
-//         pg.extend();
-//         pg.extend();
-//         debug!("Plangraph: {:?}", pg);
+    #[test]
+    fn solver_works() {
+        let p1 = Proposition::from("tired");
+        let not_p1 = p1.negate();
+        let p2 = Proposition::from("dog needs to pee");
+        let not_p2 = p2.negate();
 
-//         let solver = SimpleSolver::default();
-//         let expected = vec![hashset!{a1.clone()}, hashset!{a2.clone()}];
-//         let plan = solver.search(&pg);
-//         debug!("Plan: {:?}", plan);
-//         let actual = PlanGraph::format_plan(plan.unwrap());
-//         assert_eq!(expected, actual);
-//     }
-// }
+        let a1 = Action::new(
+            String::from("coffee"),
+            hashset!{&p1},
+            hashset!{&not_p1}
+        );
 
-// #[cfg(test)]
-// /// Prove that BTreeSet preserves ordering
-// mod btreeset_test {
-//     use std::collections::BTreeSet;
+        let a2 = Action::new(
+            String::from("walk dog"),
+            hashset!{&p2, &not_p1},
+            hashset!{&not_p2},
+        );
 
-//     #[test]
-//     fn is_sorted () {
-//         let mut b = BTreeSet::new();
-//         b.insert(2);
-//         b.insert(3);
-//         b.insert(1);
-//         assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+        let goals = hashset!{&not_p1, &not_p2};
 
-//         let mut b = BTreeSet::new();
-//         b.insert(1);
-//         b.insert(2);
-//         b.insert(3);
-//         assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
-//     }
-// }
+        let mut pg = PlanGraph::new(
+            hashset!{&p1, &p2},
+            goals,
+            hashset!{&a1, &a2}
+        );
+        pg.extend();
+        pg.extend();
+
+        let solver = SimpleSolver::default();
+        let expected = vec![hashset!{&a1}, hashset!{&a2}];
+        let actual = solver.search(&pg).unwrap();
+        assert_eq!(expected, actual);
+    }
+}
+
+#[cfg(test)]
+/// Prove that BTreeSet preserves ordering
+mod btreeset_test {
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn is_sorted () {
+        let mut b = BTreeSet::new();
+        b.insert(2);
+        b.insert(3);
+        b.insert(1);
+        assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+
+        let mut b = BTreeSet::new();
+        b.insert(1);
+        b.insert(2);
+        b.insert(3);
+        assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+}

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -32,20 +32,6 @@ struct ActionCombination<'a,
     HashMap<GoalIndex, &'a Action<'a, ActionId, PropositionId>>
 );
 
-impl<'a,
-     ActionId: Clone + Hash + Eq + Debug,
-     PropositionId: Clone + Hash + Eq + Debug + Display>
-    ActionCombination<'a, ActionId, PropositionId> {
-    pub fn as_set(&self) -> HashSet<&'a Action<ActionId, PropositionId>> {
-        self.0.values().into_iter().map(|i| *i).collect()
-    }
-
-    #[allow(dead_code)]
-    pub fn as_vec(&self) -> Vec<&'a Action<ActionId, PropositionId>> {
-        self.0.values().into_iter().map(|i| *i).collect()
-    }
-}
-
 #[derive(Clone, Debug)]
 struct GoalSetActionGenerator<'a,
                               ActionId: Debug + Hash + Clone + Eq + Ord,
@@ -379,7 +365,7 @@ impl<'a,
                 .unwrap();
 
             if let Some(goal_actions) = gen.next() {
-                debug!("Actions: {:?} for goals: {:?}", goal_actions.as_set(), goals);
+                debug!("Actions: {:?} for goals: {:?}", goal_actions, goals);
                 // If we are are on the second to last proposition
                 // layer, we are done
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -18,454 +18,454 @@ pub trait GraphPlanSolver<ActionId: Hash + Ord + Clone + Debug,
     fn search(&self, plangraph: &PlanGraph<ActionId, PropositionId>) -> Option<Solution<ActionId, PropositionId>>;
 }
 
-#[derive(Default)]
-pub struct SimpleSolver;
+// #[derive(Default)]
+// pub struct SimpleSolver;
 
-type GoalIndex = usize;
-type Attempts<ActionId, PropositionId> = HashMap<usize, BTreeSet<Action<ActionId, PropositionId>>>;
+// type GoalIndex = usize;
+// type Attempts<ActionId, PropositionId> = HashMap<usize, BTreeSet<Action<ActionId, PropositionId>>>;
 
-#[derive(Clone, Debug, PartialEq)]
-struct ActionCombination<ActionId: Hash + PartialEq + Clone + Debug ,
-                         PropositionId: Hash + Eq + PartialEq + Clone + Debug + Display>(
-    HashMap<GoalIndex, Action<ActionId, PropositionId>>
-);
+// #[derive(Clone, Debug, PartialEq)]
+// struct ActionCombination<ActionId: Hash + PartialEq + Clone + Debug ,
+//                          PropositionId: Hash + Eq + PartialEq + Clone + Debug + Display>(
+//     HashMap<GoalIndex, Action<ActionId, PropositionId>>
+// );
 
-impl<ActionId: Clone + Hash + Eq + Debug,
-     PropositionId: Clone + Hash + Eq + Debug + Display>
-    ActionCombination<ActionId, PropositionId> {
-    pub fn as_set(&self) -> HashSet<Action<ActionId, PropositionId>> {
-        self.0.values()
-            .cloned()
-            .collect()
-    }
+// impl<ActionId: Clone + Hash + Eq + Debug,
+//      PropositionId: Clone + Hash + Eq + Debug + Display>
+//     ActionCombination<ActionId, PropositionId> {
+//     pub fn as_set(&self) -> HashSet<Action<ActionId, PropositionId>> {
+//         self.0.values()
+//             .cloned()
+//             .collect()
+//     }
 
-    #[allow(dead_code)]
-    pub fn as_vec(&self) -> Vec<Action<ActionId, PropositionId>> {
-        self.0.values()
-            .cloned()
-            .collect()
-    }
-}
+//     #[allow(dead_code)]
+//     pub fn as_vec(&self) -> Vec<Action<ActionId, PropositionId>> {
+//         self.0.values()
+//             .cloned()
+//             .collect()
+//     }
+// }
 
-#[derive(Clone, Debug)]
-struct GoalSetActionGenerator<ActionId: Debug + Hash + Clone + Eq + Ord,
-                              PropositionId: Debug + Display + Hash + Clone + Eq + Ord> {
-    goals: Vec<Proposition<PropositionId>>,
-    actions: BTreeSet<Action<ActionId, PropositionId>>,
-    mutexes: Option<MutexPairs<Action<ActionId, PropositionId>>>,
-}
+// #[derive(Clone, Debug)]
+// struct GoalSetActionGenerator<ActionId: Debug + Hash + Clone + Eq + Ord,
+//                               PropositionId: Debug + Display + Hash + Clone + Eq + Ord> {
+//     goals: Vec<Proposition<PropositionId>>,
+//     actions: BTreeSet<Action<ActionId, PropositionId>>,
+//     mutexes: Option<MutexPairs<Action<ActionId, PropositionId>>>,
+// }
 
-impl<ActionId: Ord + Clone + Hash + Debug,
-     PropositionId: Ord + Clone + Hash + Debug + Display>
-    GoalSetActionGenerator<ActionId, PropositionId> {
-    pub fn new(goals: Vec<Proposition<PropositionId>>,
-               actions: BTreeSet<Action<ActionId, PropositionId>>,
-               mutexes: Option<MutexPairs<Action<ActionId, PropositionId>>>,)
-               -> GoalSetActionGenerator<ActionId, PropositionId> {
-        GoalSetActionGenerator {goals, actions, mutexes}
-    }
-}
+// impl<ActionId: Ord + Clone + Hash + Debug,
+//      PropositionId: Ord + Clone + Hash + Debug + Display>
+//     GoalSetActionGenerator<ActionId, PropositionId> {
+//     pub fn new(goals: Vec<Proposition<PropositionId>>,
+//                actions: BTreeSet<Action<ActionId, PropositionId>>,
+//                mutexes: Option<MutexPairs<Action<ActionId, PropositionId>>>,)
+//                -> GoalSetActionGenerator<ActionId, PropositionId> {
+//         GoalSetActionGenerator {goals, actions, mutexes}
+//     }
+// }
 
-impl<ActionId: Ord + Clone + Hash + Debug,
-     PropositionId: Ord + Clone + Hash + Debug + Display>
-    IntoIterator for GoalSetActionGenerator<ActionId, PropositionId> {
-    type Item = ActionCombination<ActionId, PropositionId>;
-    type IntoIter = ActionCombinationIterator<ActionId, PropositionId>;
+// impl<ActionId: Ord + Clone + Hash + Debug,
+//      PropositionId: Ord + Clone + Hash + Debug + Display>
+//     IntoIterator for GoalSetActionGenerator<ActionId, PropositionId> {
+//     type Item = ActionCombination<ActionId, PropositionId>;
+//     type IntoIter = ActionCombinationIterator<ActionId, PropositionId>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        ActionCombinationIterator::new(self)
-    }
-}
+//     fn into_iter(self) -> Self::IntoIter {
+//         ActionCombinationIterator::new(self)
+//     }
+// }
 
-#[derive(Clone, Debug)]
-struct ActionCombinationIterator<ActionId: Ord + Clone + Hash + Debug,
-                                 PropositionId: Ord + Clone + Hash + Debug + Display> {
-    meta: GoalSetActionGenerator<ActionId, PropositionId>, // defines goals we are trying achieve
-    attempts: Attempts<ActionId, PropositionId>, // previous attempts to meet a goal
-    goals_met: bool, // flag indicating all goals are met or restart
-    accum: HashMap<GoalIndex, Action<ActionId, PropositionId>> // combination of actions
-}
+// #[derive(Clone, Debug)]
+// struct ActionCombinationIterator<ActionId: Ord + Clone + Hash + Debug,
+//                                  PropositionId: Ord + Clone + Hash + Debug + Display> {
+//     meta: GoalSetActionGenerator<ActionId, PropositionId>, // defines goals we are trying achieve
+//     attempts: Attempts<ActionId, PropositionId>, // previous attempts to meet a goal
+//     goals_met: bool, // flag indicating all goals are met or restart
+//     accum: HashMap<GoalIndex, Action<ActionId, PropositionId>> // combination of actions
+// }
 
-impl<ActionId: Ord + Debug + Hash + Clone,
-     PropositionId: Ord + Debug + Display + Hash + Clone>
-    ActionCombinationIterator<ActionId, PropositionId> {
-    pub fn new(action_combinations: GoalSetActionGenerator<ActionId, PropositionId>) -> ActionCombinationIterator<ActionId, PropositionId> {
-        ActionCombinationIterator {
-            meta: action_combinations,
-            attempts: Attempts::new(),
-            goals_met: false,
-            accum: HashMap::new(),
-        }
-    }
-}
+// impl<ActionId: Ord + Debug + Hash + Clone,
+//      PropositionId: Ord + Debug + Display + Hash + Clone>
+//     ActionCombinationIterator<ActionId, PropositionId> {
+//     pub fn new(action_combinations: GoalSetActionGenerator<ActionId, PropositionId>) -> ActionCombinationIterator<ActionId, PropositionId> {
+//         ActionCombinationIterator {
+//             meta: action_combinations,
+//             attempts: Attempts::new(),
+//             goals_met: false,
+//             accum: HashMap::new(),
+//         }
+//     }
+// }
 
-impl<ActionId: Ord + Clone + Hash + Debug + PartialEq,
-     PropositionId: Ord + Clone + Hash + Debug + Display + PartialEq>
-    Iterator for ActionCombinationIterator<ActionId, PropositionId> {
-    type Item = ActionCombination<ActionId, PropositionId>;
+// impl<ActionId: Ord + Clone + Hash + Debug + PartialEq,
+//      PropositionId: Ord + Clone + Hash + Debug + Display + PartialEq>
+//     Iterator for ActionCombinationIterator<ActionId, PropositionId> {
+//     type Item = ActionCombination<ActionId, PropositionId>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let goals = &self.meta.goals;
-        let actions = &self.meta.actions;
-        let goal_len = goals.len();
+//     fn next(&mut self) -> Option<Self::Item> {
+//         let goals = &self.meta.goals;
+//         let actions = &self.meta.actions;
+//         let goal_len = goals.len();
 
-        let mut stack = VecDeque::new();
+//         let mut stack = VecDeque::new();
 
-        // If the goals have already been met, we need to look for a
-        // new combination that also meets the goals
-        if self.goals_met {
-            // Remove the previous action used to satisfy the last
-            // goal and start the loop from the last goal. This will
-            // yield a new combination or recursively back track.
-            self.goals_met = false;
-            let goal_idx = goal_len - 1;
-            self.accum.remove(&goal_idx);
-            stack.push_front(goal_idx);
-        } else {
-            stack.push_front(0);
-        }
+//         // If the goals have already been met, we need to look for a
+//         // new combination that also meets the goals
+//         if self.goals_met {
+//             // Remove the previous action used to satisfy the last
+//             // goal and start the loop from the last goal. This will
+//             // yield a new combination or recursively back track.
+//             self.goals_met = false;
+//             let goal_idx = goal_len - 1;
+//             self.accum.remove(&goal_idx);
+//             stack.push_front(goal_idx);
+//         } else {
+//             stack.push_front(0);
+//         }
 
-        while let Some(goal_idx) = stack.pop_front() {
-            let available_actions = if let Some(acts) = self.attempts.get(&goal_idx) {
-                acts.to_owned()
-            } else {
-                let goal = &goals[goal_idx];
-                debug!("Working on goal {:?}", goal);
-                let mut available = BTreeSet::new();
-                // Only actions that produce the goal and are not
-                // mutex with any other actions and have not
-                // already been attempted in combination with the
-                // other attempted actions and are not mutex with
-                // any other action
-                for a in actions {
-                    // Early continue since the later checks are
-                    // more expensive
-                    if !a.effects.contains(goal) {
-                        continue
-                    };
+//         while let Some(goal_idx) = stack.pop_front() {
+//             let available_actions = if let Some(acts) = self.attempts.get(&goal_idx) {
+//                 acts.to_owned()
+//             } else {
+//                 let goal = &goals[goal_idx];
+//                 debug!("Working on goal {:?}", goal);
+//                 let mut available = BTreeSet::new();
+//                 // Only actions that produce the goal and are not
+//                 // mutex with any other actions and have not
+//                 // already been attempted in combination with the
+//                 // other attempted actions and are not mutex with
+//                 // any other action
+//                 for a in actions {
+//                     // Early continue since the later checks are
+//                     // more expensive
+//                     if !a.effects.contains(goal) {
+//                         continue
+//                     };
 
-                    // Early break if we already know this action
-                    // works for the goal from previous attempts
-                    if self.accum.get(&goal_idx).map(|i| i == a).unwrap_or(false) {
-                        available.insert(a.clone());
-                        break
-                    };
+//                     // Early break if we already know this action
+//                     // works for the goal from previous attempts
+//                     if self.accum.get(&goal_idx).map(|i| i == a).unwrap_or(false) {
+//                         available.insert(a.clone());
+//                         break
+//                     };
 
-                    // Check if this action is mutex with any of
-                    // the other accumulated actions
-                    let acts = self.accum.clone();
-                    let pairs = pairs_from_sets(
-                        hashset!{a.clone()},
-                        ActionCombination(acts).as_set()
-                    );
-                    debug!("Checking pairs: {:?} against mutexes: {:?}", pairs, &self.meta.mutexes);
+//                     // Check if this action is mutex with any of
+//                     // the other accumulated actions
+//                     let acts = self.accum.clone();
+//                     let pairs = pairs_from_sets(
+//                         hashset!{a.clone()},
+//                         ActionCombination(acts).as_set()
+//                     );
+//                     debug!("Checking pairs: {:?} against mutexes: {:?}", pairs, &self.meta.mutexes);
 
-                    if let Some(muxes) = &self.meta.mutexes {
-                        if muxes.intersection(&pairs).next().is_none() {
-                            available.insert(a.clone());
-                        }
-                    };
-                };
-                available
-            };
+//                     if let Some(muxes) = &self.meta.mutexes {
+//                         if muxes.intersection(&pairs).next().is_none() {
+//                             available.insert(a.clone());
+//                         }
+//                     };
+//                 };
+//                 available
+//             };
 
-            if available_actions.is_empty() {
-                if goal_idx == 0 {
-                    // Complete fail
-                    break;
-                }
-                debug!("Unable to find actions for goal {:?}. Going back to previous goal...", goal_idx);
-                // Clear attempts for this goal so finding an action
-                // can be retried with a new set of actions
-                self.attempts.remove(&goal_idx);
-                // Backtrack to the previous goal
-                stack.push_front(goal_idx - 1);
-            } else {
-                let next_action = available_actions.iter().next().unwrap();
-                // TODO only add the action if the goal isn't met yet
-                self.accum.insert(goal_idx, next_action.clone());
+//             if available_actions.is_empty() {
+//                 if goal_idx == 0 {
+//                     // Complete fail
+//                     break;
+//                 }
+//                 debug!("Unable to find actions for goal {:?}. Going back to previous goal...", goal_idx);
+//                 // Clear attempts for this goal so finding an action
+//                 // can be retried with a new set of actions
+//                 self.attempts.remove(&goal_idx);
+//                 // Backtrack to the previous goal
+//                 stack.push_front(goal_idx - 1);
+//             } else {
+//                 let next_action = available_actions.iter().next().unwrap();
+//                 // TODO only add the action if the goal isn't met yet
+//                 self.accum.insert(goal_idx, next_action.clone());
 
-                // Add to previous attempts in case we need to backtrack
-                let mut remaining_actions = available_actions.clone();
-                remaining_actions.remove(&next_action);
-                self.attempts.insert(goal_idx, remaining_actions);
+//                 // Add to previous attempts in case we need to backtrack
+//                 let mut remaining_actions = available_actions.clone();
+//                 remaining_actions.remove(&next_action);
+//                 self.attempts.insert(goal_idx, remaining_actions);
 
-                // TODO Implement minimal action sets i.e handle if
-                // this action staisfies more than one
-                // goal. Otherwise, the speed of finding a solution is
-                // dependent on the ordering of goals
-                // From the paper: no action can be
-                // removed from A so that the add effects of the
-                // actions remaining still contain G
+//                 // TODO Implement minimal action sets i.e handle if
+//                 // this action staisfies more than one
+//                 // goal. Otherwise, the speed of finding a solution is
+//                 // dependent on the ordering of goals
+//                 // From the paper: no action can be
+//                 // removed from A so that the add effects of the
+//                 // actions remaining still contain G
 
-                // Proceed to the next goal
-                if goal_idx < goal_len - 1 {
-                    stack.push_front(goal_idx + 1);
-                } else {
-                    self.goals_met = true;
-                }
-            };
-        };
+//                 // Proceed to the next goal
+//                 if goal_idx < goal_len - 1 {
+//                     stack.push_front(goal_idx + 1);
+//                 } else {
+//                     self.goals_met = true;
+//                 }
+//             };
+//         };
 
-        if self.goals_met {
-            Some(ActionCombination(self.accum.clone()))
-        } else {
-            None
-        }
-    }
-}
+//         if self.goals_met {
+//             Some(ActionCombination(self.accum.clone()))
+//         } else {
+//             None
+//         }
+//     }
+// }
 
 
-#[cfg(test)]
-mod goal_set_action_generator_test {
-    use super::*;
+// #[cfg(test)]
+// mod goal_set_action_generator_test {
+//     use super::*;
 
-    #[test]
-    fn single_goal() {
-        let p1 = Proposition::from("coffee");
-        let p2 = Proposition::from("caffeinated");
-        let goals = vec![p2.clone()];
-        let mut actions = BTreeSet::new();
-        let a1 = Action::new(
-            String::from("drink coffee"),
-            hashset!{&p1},
-            hashset!{&p2}
-        );
-        actions.insert(a1.clone());
-        let mutexes = Some(MutexPairs::new());
-        let expected = ActionCombination(hashmap!{0 => a1});
-        let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
-            .into_iter()
-            .next()
-            .unwrap();
-        assert_eq!(expected, actual);
-    }
+//     #[test]
+//     fn single_goal() {
+//         let p1 = Proposition::from("coffee");
+//         let p2 = Proposition::from("caffeinated");
+//         let goals = vec![p2.clone()];
+//         let mut actions = BTreeSet::new();
+//         let a1 = Action::new(
+//             String::from("drink coffee"),
+//             hashset!{&p1},
+//             hashset!{&p2}
+//         );
+//         actions.insert(a1.clone());
+//         let mutexes = Some(MutexPairs::new());
+//         let expected = ActionCombination(hashmap!{0 => a1});
+//         let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
+//             .into_iter()
+//             .next()
+//             .unwrap();
+//         assert_eq!(expected, actual);
+//     }
 
-    #[test]
-    fn multiple_goals() {
-        let p1 = Proposition::from("coffee");
-        let p2 = Proposition::from("caffeinated");
-        let p3 = Proposition::from("breakfast");
-        let p4 = Proposition::from("full");
-        let goals = vec![p2.clone(), p4.clone()];
-        let mut actions = BTreeSet::new();
-        let a1 = Action::new(
-            String::from("drink coffee"),
-            hashset!{&p1},
-            hashset!{&p2}
-        );
-        actions.insert(a1.clone());
+//     #[test]
+//     fn multiple_goals() {
+//         let p1 = Proposition::from("coffee");
+//         let p2 = Proposition::from("caffeinated");
+//         let p3 = Proposition::from("breakfast");
+//         let p4 = Proposition::from("full");
+//         let goals = vec![p2.clone(), p4.clone()];
+//         let mut actions = BTreeSet::new();
+//         let a1 = Action::new(
+//             String::from("drink coffee"),
+//             hashset!{&p1},
+//             hashset!{&p2}
+//         );
+//         actions.insert(a1.clone());
 
-        let a2 = Action::new(
-            String::from("eat breakfast"),
-            hashset!{&p3},
-            hashset!{&p4}
-        );
-        actions.insert(a2.clone());
+//         let a2 = Action::new(
+//             String::from("eat breakfast"),
+//             hashset!{&p3},
+//             hashset!{&p4}
+//         );
+//         actions.insert(a2.clone());
 
-        let mutexes = Some(MutexPairs::new());
-        let expected = ActionCombination(hashmap!{0 => a1.clone(), 1 => a2.clone()});
-        let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
-            .into_iter()
-            .next()
-            .unwrap();
-        assert_eq!(expected, actual);
-    }
+//         let mutexes = Some(MutexPairs::new());
+//         let expected = ActionCombination(hashmap!{0 => a1.clone(), 1 => a2.clone()});
+//         let actual = GoalSetActionGenerator::new(goals, actions, mutexes)
+//             .into_iter()
+//             .next()
+//             .unwrap();
+//         assert_eq!(expected, actual);
+//     }
 
-    #[test]
-    fn yields_all() {
-        let p1 = Proposition::from("tea");
-        let p2 = Proposition::from("coffee");
-        let p3 = Proposition::from("caffeinated");
-        let p4 = Proposition::from("scone");
-        let p5 = Proposition::from("muffin");
-        let p6 = Proposition::from("full");
-        let goals = vec![p3.clone(), p6.clone()];
-        let mut actions = BTreeSet::new();
+//     #[test]
+//     fn yields_all() {
+//         let p1 = Proposition::from("tea");
+//         let p2 = Proposition::from("coffee");
+//         let p3 = Proposition::from("caffeinated");
+//         let p4 = Proposition::from("scone");
+//         let p5 = Proposition::from("muffin");
+//         let p6 = Proposition::from("full");
+//         let goals = vec![p3.clone(), p6.clone()];
+//         let mut actions = BTreeSet::new();
 
-        let a1 = Action::new(
-            String::from("drink coffee"),
-            hashset!{&p2},
-            hashset!{&p3}
-        );
-        actions.insert(a1.clone());
+//         let a1 = Action::new(
+//             String::from("drink coffee"),
+//             hashset!{&p2},
+//             hashset!{&p3}
+//         );
+//         actions.insert(a1.clone());
 
-        let a2 = Action::new(
-            String::from("drink tea"),
-            hashset!{&p1},
-            hashset!{&p3}
-        );
-        actions.insert(a2.clone());
+//         let a2 = Action::new(
+//             String::from("drink tea"),
+//             hashset!{&p1},
+//             hashset!{&p3}
+//         );
+//         actions.insert(a2.clone());
 
-        let a3 = Action::new(
-            String::from("eat scone"),
-            hashset!{&p4},
-            hashset!{&p6}
-        );
-        actions.insert(a3.clone());
+//         let a3 = Action::new(
+//             String::from("eat scone"),
+//             hashset!{&p4},
+//             hashset!{&p6}
+//         );
+//         actions.insert(a3.clone());
 
-        let a4 = Action::new(
-            String::from("eat muffin"),
-            hashset!{&p5},
-            hashset!{&p6}
-        );
-        actions.insert(a4.clone());
+//         let a4 = Action::new(
+//             String::from("eat muffin"),
+//             hashset!{&p5},
+//             hashset!{&p6}
+//         );
+//         actions.insert(a4.clone());
 
-        let mutexes = Some(MutexPairs::new());
-        let expected = vec![
-            vec![a1.clone(), a4.clone()],
-            vec![a1.clone(), a3.clone()],
-            vec![a2.clone(), a4.clone()],
-            vec![a2.clone(), a3.clone()],
-        ];
-        let generator = GoalSetActionGenerator::new(goals, actions, mutexes);
-        let actual: Vec<Vec<Action<_, _>>> = generator.into_iter()
-            .map(|combo| {let mut i = combo.as_vec(); i.sort(); i})
-            .collect();
+//         let mutexes = Some(MutexPairs::new());
+//         let expected = vec![
+//             vec![a1.clone(), a4.clone()],
+//             vec![a1.clone(), a3.clone()],
+//             vec![a2.clone(), a4.clone()],
+//             vec![a2.clone(), a3.clone()],
+//         ];
+//         let generator = GoalSetActionGenerator::new(goals, actions, mutexes);
+//         let actual: Vec<Vec<Action<_, _>>> = generator.into_iter()
+//             .map(|combo| {let mut i = combo.as_vec(); i.sort(); i})
+//             .collect();
 
-        assert_eq!(expected, actual);
-    }
-}
+//         assert_eq!(expected, actual);
+//     }
+// }
 
-type SearchStack<ActionId, PropositionId> = VecDeque<(usize, Vec<Proposition<PropositionId>>, Option<ActionCombinationIterator<ActionId, PropositionId>>)>;
+// type SearchStack<ActionId, PropositionId> = VecDeque<(usize, Vec<Proposition<PropositionId>>, Option<ActionCombinationIterator<ActionId, PropositionId>>)>;
 
-impl<ActionId: Ord + Clone + Hash + Debug,
-     PropositionId: Ord + Clone + Hash + Debug + Display>
-    GraphPlanSolver<ActionId, PropositionId> for SimpleSolver {
-    fn search(&self, plangraph: &PlanGraph<ActionId, PropositionId>) -> Option<Solution<ActionId, PropositionId>> {
-        let mut success = false;
-        let mut plan = Vec::new();
-        let mut failed_goals_memo: HashSet<(usize, Vec<Proposition<PropositionId>>)> = HashSet::new();
+// impl<ActionId: Ord + Clone + Hash + Debug,
+//      PropositionId: Ord + Clone + Hash + Debug + Display>
+//     GraphPlanSolver<ActionId, PropositionId> for SimpleSolver {
+//     fn search(&self, plangraph: &PlanGraph<ActionId, PropositionId>) -> Option<Solution<ActionId, PropositionId>> {
+//         let mut success = false;
+//         let mut plan = Vec::new();
+//         let mut failed_goals_memo: HashSet<(usize, Vec<Proposition<PropositionId>>)> = HashSet::new();
 
-        // Initialize the loop
-        let mut stack: SearchStack<ActionId, PropositionId> = VecDeque::new();
-        let init_goals = Vec::from_iter(plangraph.goals.clone());
-        let init_layer_idx = plangraph.layers.len() - 1;
-        let init_action_gen = None;
+//         // Initialize the loop
+//         let mut stack: SearchStack<ActionId, PropositionId> = VecDeque::new();
+//         let init_goals = Vec::from_iter(plangraph.goals.clone());
+//         let init_layer_idx = plangraph.layers.len() - 1;
+//         let init_action_gen = None;
 
-        stack.push_front((init_layer_idx, init_goals, init_action_gen));
+//         stack.push_front((init_layer_idx, init_goals, init_action_gen));
 
-        while let Some((idx, goals, action_gen)) = stack.pop_front() {
-            debug!("Working on layer {:?} with goals {:?}", idx, goals);
-            // Check if the goal set is unsolvable at level idx
-            if failed_goals_memo.contains(&(idx, goals.clone())) {
-                // Continue to previous layer (the next element in the queue)
-                continue;
-            }
+//         while let Some((idx, goals, action_gen)) = stack.pop_front() {
+//             debug!("Working on layer {:?} with goals {:?}", idx, goals);
+//             // Check if the goal set is unsolvable at level idx
+//             if failed_goals_memo.contains(&(idx, goals.clone())) {
+//                 // Continue to previous layer (the next element in the queue)
+//                 continue;
+//             }
 
-            // Note: This is a btreeset so ordering is guaranteed
-            let actions = plangraph.actions_at_layer(idx - 1)
-                .expect("Failed to get actions");
-            let mutexes = plangraph.mutex_actions.get(&(idx - 1)).cloned();
-            let mut gen = action_gen
-                .or_else(|| Some(GoalSetActionGenerator::new(goals.clone(),
-                                                             actions.clone(),
-                                                             mutexes).into_iter()))
-                .unwrap();
+//             // Note: This is a btreeset so ordering is guaranteed
+//             let actions = plangraph.actions_at_layer(idx - 1)
+//                 .expect("Failed to get actions");
+//             let mutexes = plangraph.mutex_actions.get(&(idx - 1)).cloned();
+//             let mut gen = action_gen
+//                 .or_else(|| Some(GoalSetActionGenerator::new(goals.clone(),
+//                                                              actions.clone(),
+//                                                              mutexes).into_iter()))
+//                 .unwrap();
 
-            if let Some(goal_actions) = gen.next() {
-                debug!("Actions: {:?} for goals: {:?}", goal_actions.as_set(), goals);
-                // If we are are on the second to last proposition
-                // layer, we are done
-                if (idx - 2) == 0 {
-                    plan.push(goal_actions.as_set());
-                    debug!("Found plan! {:?}", plan);
-                    success = true;
-                    break;
-                } else {
-                    plan.push(goal_actions.as_set());
-                    let next_goals = goal_actions.as_set().into_iter()
-                        .flat_map(|action| action.reqs)
-                        .unique()
-                        .collect();
-                    // Add this layer back into the queue incase we need to backtrack
-                    stack.push_front((idx, goals, Some(gen)));
-                    stack.push_front((idx - 2, next_goals, None));
-                };
-            } else {
-                debug!("Unable to find actions for goals {:?} from actions {:?}",
-                       goals, actions);
-                // Record the failed goals at level idx
-                failed_goals_memo.insert((idx, goals.clone()));
-                // Remove the last step in the plan from which this
-                // set of goals comes from
-                plan.pop();
-                // Backtrack to previous layer and goalset or nothing
-                // (the next element in the queue)
-            }
-        };
+//             if let Some(goal_actions) = gen.next() {
+//                 debug!("Actions: {:?} for goals: {:?}", goal_actions.as_set(), goals);
+//                 // If we are are on the second to last proposition
+//                 // layer, we are done
+//                 if (idx - 2) == 0 {
+//                     plan.push(goal_actions.as_set());
+//                     debug!("Found plan! {:?}", plan);
+//                     success = true;
+//                     break;
+//                 } else {
+//                     plan.push(goal_actions.as_set());
+//                     let next_goals = goal_actions.as_set().into_iter()
+//                         .flat_map(|action| action.reqs)
+//                         .unique()
+//                         .collect();
+//                     // Add this layer back into the queue incase we need to backtrack
+//                     stack.push_front((idx, goals, Some(gen)));
+//                     stack.push_front((idx - 2, next_goals, None));
+//                 };
+//             } else {
+//                 debug!("Unable to find actions for goals {:?} from actions {:?}",
+//                        goals, actions);
+//                 // Record the failed goals at level idx
+//                 failed_goals_memo.insert((idx, goals.clone()));
+//                 // Remove the last step in the plan from which this
+//                 // set of goals comes from
+//                 plan.pop();
+//                 // Backtrack to previous layer and goalset or nothing
+//                 // (the next element in the queue)
+//             }
+//         };
 
-        if success {
-            // Since this solver goes from the last layer to the
-            // first, we need to reverse the plan
-            plan.reverse();
-            Some(plan)
-        } else {
-            None
-        }
-    }
-}
+//         if success {
+//             // Since this solver goes from the last layer to the
+//             // first, we need to reverse the plan
+//             plan.reverse();
+//             Some(plan)
+//         } else {
+//             None
+//         }
+//     }
+// }
 
-#[cfg(test)]
-mod simple_solver_test {
-    use super::*;
+// #[cfg(test)]
+// mod simple_solver_test {
+//     use super::*;
 
-    #[test]
-    fn solver_works() {
-        let p1 = Proposition::from("tired");
-        let not_p1 = p1.negate();
-        let p2 = Proposition::from("dog needs to pee");
-        let not_p2 = p2.negate();
+//     #[test]
+//     fn solver_works() {
+//         let p1 = Proposition::from("tired");
+//         let not_p1 = p1.negate();
+//         let p2 = Proposition::from("dog needs to pee");
+//         let not_p2 = p2.negate();
 
-        let a1 = Action::new(
-            String::from("coffee"),
-            hashset!{&p1},
-            hashset!{&not_p1}
-        );
+//         let a1 = Action::new(
+//             String::from("coffee"),
+//             hashset!{&p1},
+//             hashset!{&not_p1}
+//         );
 
-        let a2 = Action::new(
-            String::from("walk dog"),
-            hashset!{&p2, &not_p1},
-            hashset!{&not_p2},
-        );
+//         let a2 = Action::new(
+//             String::from("walk dog"),
+//             hashset!{&p2, &not_p1},
+//             hashset!{&not_p2},
+//         );
 
-        let goals = hashset!{not_p1, not_p2};
+//         let goals = hashset!{not_p1, not_p2};
 
-        let mut pg = PlanGraph::new(
-            hashset!{p1, p2},
-            goals,
-            hashset!{a1.clone(), a2.clone()}
-        );
-        pg.extend();
-        pg.extend();
-        debug!("Plangraph: {:?}", pg);
+//         let mut pg = PlanGraph::new(
+//             hashset!{p1, p2},
+//             goals,
+//             hashset!{a1.clone(), a2.clone()}
+//         );
+//         pg.extend();
+//         pg.extend();
+//         debug!("Plangraph: {:?}", pg);
 
-        let solver = SimpleSolver::default();
-        let expected = vec![hashset!{a1.clone()}, hashset!{a2.clone()}];
-        let plan = solver.search(&pg);
-        debug!("Plan: {:?}", plan);
-        let actual = PlanGraph::format_plan(plan.unwrap());
-        assert_eq!(expected, actual);
-    }
-}
+//         let solver = SimpleSolver::default();
+//         let expected = vec![hashset!{a1.clone()}, hashset!{a2.clone()}];
+//         let plan = solver.search(&pg);
+//         debug!("Plan: {:?}", plan);
+//         let actual = PlanGraph::format_plan(plan.unwrap());
+//         assert_eq!(expected, actual);
+//     }
+// }
 
-#[cfg(test)]
-/// Prove that BTreeSet preserves ordering
-mod btreeset_test {
-    use std::collections::BTreeSet;
+// #[cfg(test)]
+// /// Prove that BTreeSet preserves ordering
+// mod btreeset_test {
+//     use std::collections::BTreeSet;
 
-    #[test]
-    fn is_sorted () {
-        let mut b = BTreeSet::new();
-        b.insert(2);
-        b.insert(3);
-        b.insert(1);
-        assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+//     #[test]
+//     fn is_sorted () {
+//         let mut b = BTreeSet::new();
+//         b.insert(2);
+//         b.insert(3);
+//         b.insert(1);
+//         assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
 
-        let mut b = BTreeSet::new();
-        b.insert(1);
-        b.insert(2);
-        b.insert(3);
-        assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
-    }
-}
+//         let mut b = BTreeSet::new();
+//         b.insert(1);
+//         b.insert(2);
+//         b.insert(3);
+//         assert_eq!(b.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+//     }
+// }


### PR DESCRIPTION
## Summary

Refactors `PlanGraph`, `Action`, `Layer`, `Proposition`, and `SimpleSolver` to hold references. This greatly reduces the need to clone structs at the cost of more complex lifetime accounting and a potentially less convenient public facing API via `GraphPlan`. For example the caller needs to construct all of the propositions and actions including negations and maintenance actions (some helper functions and or macros would help here). 

I've also cleaned up sections that were doing unnecessary work (see the `plangraph` module) and doing some overall tidying.

## Performance

According to the benchmarks via `criterion`, this change reduces the median time to running the bench program by -98% compared to v0.5.0.

<img width="631" alt="Screen Shot 2020-02-09 at 12 48 15 PM" src="https://user-images.githubusercontent.com/627790/74109985-41f6c100-4b3d-11ea-8a33-2453ddf8d776.png">

## TODO
- [ ] Re-enable instantiating a `GraphPlan` from toml
- [x] Re-implement negation mutex to `Layer.proposition_mutexes` (this probably won't impact benchmarks much since it's an O(1) operation)
- [x] Helpers for creating maintenance actions and negated propositions
